### PR TITLE
Add Linux CPU load support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ time = "0.1"
 chrono = "0.4"
 lazy_static = "0.2"
 bytesize = "0.1"
+nom = "3.2"
 
 [target.'cfg(not(windows))'.dependencies]
 libc = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,10 @@
 extern crate bytesize;
 extern crate time;
 extern crate chrono;
-#[macro_use] extern crate lazy_static;
+#[macro_use]
+extern crate lazy_static;
+#[macro_use]
+extern crate nom;
 
 pub mod platform;
 pub mod data;

--- a/src/platform/bsd.rs
+++ b/src/platform/bsd.rs
@@ -1,5 +1,4 @@
 use libc::c_int;
-use std::ops::Sub;
 use data::*;
 
 lazy_static! {
@@ -24,33 +23,15 @@ pub struct sysctl_cpu {
     idle: usize,
 }
 
-impl<'a> Sub<&'a sysctl_cpu> for sysctl_cpu {
-    type Output = sysctl_cpu;
-
-    #[inline(always)]
-    fn sub(self, rhs: &sysctl_cpu) -> sysctl_cpu {
-        sysctl_cpu {
-            user: self.user - rhs.user,
-            nice: self.nice - rhs.nice,
-            system: self.system - rhs.system,
-            interrupt: self.interrupt - rhs.interrupt,
-            idle: self.idle - rhs.idle,
-        }
-    }
-}
-
-impl sysctl_cpu {
-    pub fn to_cpuload(&self) -> CPULoad {
-        let mut total = (self.user + self.nice + self.system + self.interrupt + self.idle) as f32;
-        if total < 0.00001 {
-            total = 0.00001;
-        }
-        CPULoad {
-            user: self.user as f32 / total,
-            nice: self.nice as f32 / total,
-            system: self.system as f32 / total,
-            interrupt: self.interrupt as f32 / total,
-            idle: self.idle as f32 / total,
+impl From<sysctl_cpu> for CpuTime {
+    fn from(cpu: sysctl_cpu) -> CpuTime {
+        CpuTime {
+            user: cpu.user,
+            nice: cpu.nice,
+            system: cpu.system,
+            interrupt: cpu.interrupt,
+            idle: cpu.idle,
+            other: 0,
         }
     }
 }

--- a/src/platform/freebsd.rs
+++ b/src/platform/freebsd.rs
@@ -146,12 +146,12 @@ impl Platform for PlatformImpl {
 }
 
 
-fn measure_cpu() -> io::Result<Vec<bsd::sysctl_cpu>> {
+fn measure_cpu() -> io::Result<Vec<CpuTime>> {
     let cpus = *CP_TIMES_SIZE / mem::size_of::<bsd::sysctl_cpu>();
     let mut data: Vec<bsd::sysctl_cpu> = Vec::with_capacity(cpus);
     unsafe { data.set_len(cpus) };
     sysctl!(KERN_CP_TIMES, &mut data[0], *CP_TIMES_SIZE);
-    Ok(data)
+    Ok(data.into_iter().map(|cpu| cpu.into()).collect())
 }
 
 fn zfs_arc_size() -> io::Result<usize> {

--- a/src/platform/openbsd.rs
+++ b/src/platform/openbsd.rs
@@ -123,8 +123,9 @@ impl Platform for PlatformImpl {
     }
 }
 
-fn measure_cpu() -> io::Result<Vec<bsd::sysctl_cpu>> {
-    let mut cpus: usize = 0; sysctl!(HW_NCPU, &mut cpus, mem::size_of::<usize>());
+fn measure_cpu() -> io::Result<Vec<CpuTime>> {
+    let mut cpus: usize = 0;
+    sysctl!(HW_NCPU, &mut cpus, mem::size_of::<usize>());
     let mut data: Vec<bsd::sysctl_cpu> = Vec::with_capacity(cpus);
     unsafe { data.set_len(cpus) };
     for i in 0..cpus {
@@ -132,7 +133,7 @@ fn measure_cpu() -> io::Result<Vec<bsd::sysctl_cpu>> {
         mib[2] = i as i32;
         sysctl!(mib, &mut data[i], mem::size_of::<bsd::sysctl_cpu>());
     }
-    Ok(data)
+    Ok(data.into_iter().map(|cpu| cpu.into()).collect())
 }
 
 #[derive(Default, Debug)]


### PR DESCRIPTION
Linux CPU load support is retrieved from `/proc/stat`, parsed using the nom crate.

Disclaimer: I did my best to ensure that the BSD versions still compile, but I'm unable to test them.