### PR TITLE
Implement Linux mount information gathering

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ nom = "3.2"
 [target.'cfg(not(windows))'.dependencies]
 libc = "0.2"
 
+[target.'cfg(unix)'.dependencies]
+nix = "0.9"
+
 [target.'cfg(windows)'.dependencies]
 winapi = "0.2"
 kernel32-sys = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,6 @@ nom = "3.2"
 [target.'cfg(not(windows))'.dependencies]
 libc = "0.2"
 
-[target.'cfg(unix)'.dependencies]
-nix = "0.9"
-
 [target.'cfg(windows)'.dependencies]
 winapi = "0.2"
 kernel32-sys = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@
 
 #[cfg(not(windows))]
 extern crate libc;
+#[cfg(unix)]
+extern crate nix;
 #[cfg(windows)]
 extern crate winapi;
 #[cfg(windows)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,6 @@
 
 #[cfg(not(windows))]
 extern crate libc;
-#[cfg(unix)]
-extern crate nix;
 #[cfg(windows)]
 extern crate winapi;
 #[cfg(windows)]


### PR DESCRIPTION
The `nix` crate provides sensible wrappers around *nix syscalls and library calls, including `statvfs()`, which combined with a `/proc/mounts` parser makes it easy to retrieve filesystem information on Linux. It might also be useful in the BSD code (but I'm afraid I can't help with that).

Tested on my local machine, seems to give sensible answers with free/available/total size, and lists all my filesystems.