### PR TITLE
[WIP] Port to (upcoming) bytesize v0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/myfreeweb/systemstat"
 time = "0.1"
 chrono = "0.4"
 lazy_static = "0.2"
-bytesize = "0.1"
+bytesize = "0.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 nom = "3.2"

--- a/examples/info.rs
+++ b/examples/info.rs
@@ -43,7 +43,7 @@ fn main() {
     }
 
     match sys.memory() {
-        Ok(mem) => println!("\nMemory: {} used / {} ({} bytes) total ({:?})", mem.total - mem.free, mem.total, mem.total.as_usize(), mem.platform_memory),
+        Ok(mem) => println!("\nMemory: {} used / {} ({} bytes) total ({:?})", mem.total - mem.free, mem.total, mem.total.as_u64(), mem.platform_memory),
         Err(x) => println!("\nMemory: error: {}", x)
     }
 

--- a/src/platform/freebsd.rs
+++ b/src/platform/freebsd.rs
@@ -197,9 +197,9 @@ impl statfs {
     fn to_fs(&self) -> Filesystem {
         Filesystem {
             files: self.f_files as usize - self.f_ffree as usize,
-            free: ByteSize::b(self.f_bfree as usize * self.f_bsize as usize),
-            avail: ByteSize::b(self.f_bavail as usize * self.f_bsize as usize),
-            total: ByteSize::b(self.f_blocks as usize * self.f_bsize as usize),
+            free: ByteSize::b(self.f_bfree * self.f_bsize),
+            avail: ByteSize::b(self.f_bavail as u64 * self.f_bsize),
+            total: ByteSize::b(self.f_blocks * self.f_bsize),
             name_max: self.f_namemax as usize,
             fs_type: unsafe { ffi::CStr::from_ptr(&self.f_fstypename[0]).to_string_lossy().into_owned() },
             fs_mounted_from: unsafe { ffi::CStr::from_ptr(&self.f_mntfromname[0]).to_string_lossy().into_owned() },

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -113,7 +113,7 @@ named!(
         tag!(":") >>
         value: usize_s >>
         ws!(tag!("kB")) >>
-        ((key, ByteSize::kib(value)))
+        ((key, ByteSize::kib(value as u64)))
     ))
 );
 
@@ -188,9 +188,9 @@ fn stat_mount(mount: ProcMountsData) -> io::Result<Filesystem> {
     match result {
         0 => Ok(Filesystem {
             files: info.f_files as usize,
-            free: ByteSize::b(info.f_bfree as usize * info.f_bsize as usize),
-            avail: ByteSize::b(info.f_bavail as usize * info.f_bsize as usize),
-            total: ByteSize::b(info.f_blocks as usize * info.f_bsize as usize),
+            free: ByteSize::b(info.f_bfree as u64 * info.f_bsize as u64),
+            avail: ByteSize::b(info.f_bavail as u64 * info.f_bsize as u64),
+            total: ByteSize::b(info.f_blocks as u64 * info.f_bsize as u64),
             name_max: info.f_namemax as usize,
             fs_type: mount.fstype,
             fs_mounted_from: mount.source,
@@ -235,22 +235,22 @@ impl Platform for PlatformImpl {
                 let mut meminfo = BTreeMap::new();
                 let mut info: sysinfo = unsafe { mem::zeroed() };
                 unsafe { sysinfo(&mut info) };
-                let unit = info.mem_unit as usize;
+                let unit = info.mem_unit as u64;
                 meminfo.insert(
                     "MemTotal".to_owned(),
-                    ByteSize::b(info.totalram as usize * unit),
+                    ByteSize::b(info.totalram as u64 * unit),
                 );
                 meminfo.insert(
                     "MemFree".to_owned(),
-                    ByteSize::b(info.freeram as usize * unit),
+                    ByteSize::b(info.freeram as u64 * unit),
                 );
                 meminfo.insert(
                     "Shmem".to_owned(),
-                    ByteSize::b(info.sharedram as usize * unit),
+                    ByteSize::b(info.sharedram as u64 * unit),
                 );
                 meminfo.insert(
                     "Buffers".to_owned(),
-                    ByteSize::b(info.bufferram as usize * unit),
+                    ByteSize::b(info.bufferram as u64 * unit),
                 );
                 Ok(meminfo)
             })

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -64,7 +64,7 @@ mod tests {
     #[test]
     fn test_memory() {
         let mem = PlatformImpl::new().memory().unwrap();
-        assert!(mem.free.as_usize() > 1024 && mem.total.as_usize() > 1024);
+        assert!(mem.free.as_u64() > 1024 && mem.total.as_u64() > 1024);
     }
 
     #[test]

--- a/src/platform/openbsd.rs
+++ b/src/platform/openbsd.rs
@@ -60,14 +60,14 @@ impl Platform for PlatformImpl {
     fn memory(&self) -> io::Result<Memory> {
         let mut uvm_info = uvmexp::default(); sysctl!(VM_UVMEXP, &mut uvm_info, mem::size_of::<uvmexp>());
         let mut bcache_info = bcachestats::default(); sysctl!(VFS_BCACHESTAT, &mut bcache_info, mem::size_of::<bcachestats>());
-        let total = ByteSize::kib((uvm_info.npages << *bsd::PAGESHIFT) as usize);
+        let total = ByteSize::kib((uvm_info.npages << *bsd::PAGESHIFT) as u64);
         let pmem = PlatformMemory {
-            active: ByteSize::kib((uvm_info.active << *bsd::PAGESHIFT) as usize),
-            inactive: ByteSize::kib((uvm_info.inactive << *bsd::PAGESHIFT) as usize),
-            wired: ByteSize::kib((uvm_info.wired << *bsd::PAGESHIFT) as usize),
-            cache: ByteSize::kib((bcache_info.numbufpages << *bsd::PAGESHIFT) as usize),
-            free: ByteSize::kib((uvm_info.free << *bsd::PAGESHIFT) as usize),
-            paging: ByteSize::kib((uvm_info.paging << *bsd::PAGESHIFT) as usize),
+            active: ByteSize::kib((uvm_info.active << *bsd::PAGESHIFT) as u64),
+            inactive: ByteSize::kib((uvm_info.inactive << *bsd::PAGESHIFT) as u64),
+            wired: ByteSize::kib((uvm_info.wired << *bsd::PAGESHIFT) as u64),
+            cache: ByteSize::kib((bcache_info.numbufpages << *bsd::PAGESHIFT) as u64),
+            free: ByteSize::kib((uvm_info.free << *bsd::PAGESHIFT) as u64),
+            paging: ByteSize::kib((uvm_info.paging << *bsd::PAGESHIFT) as u64),
         };
         Ok(Memory {
             total: total,

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -38,13 +38,13 @@ impl Platform for PlatformImpl {
         unsafe { kernel32::GlobalMemoryStatusEx(&mut status); }
         let pm = PlatformMemory {
             load: status.dwMemoryLoad,
-            total_phys: ByteSize::b(status.ullTotalPhys as usize),
-            avail_phys: ByteSize::b(status.ullAvailPhys as usize),
-            total_pagefile: ByteSize::b(status.ullTotalPageFile as usize),
-            avail_pagefile: ByteSize::b(status.ullAvailPageFile as usize),
-            total_virt: ByteSize::b(status.ullTotalVirtual as usize),
-            avail_virt: ByteSize::b(status.ullAvailVirtual as usize),
-            avail_ext: ByteSize::b(status.ullAvailExtendedVirtual as usize),
+            total_phys: ByteSize::b(status.ullTotalPhys as u64),
+            avail_phys: ByteSize::b(status.ullAvailPhys as u64),
+            total_pagefile: ByteSize::b(status.ullTotalPageFile as u64),
+            avail_pagefile: ByteSize::b(status.ullAvailPageFile as u64),
+            total_virt: ByteSize::b(status.ullTotalVirtual as u64),
+            avail_virt: ByteSize::b(status.ullAvailVirtual as u64),
+            avail_ext: ByteSize::b(status.ullAvailExtendedVirtual as u64),
         };
         Ok(Memory {
             total: pm.total_phys,


### PR DESCRIPTION
Hi, [I just broke the bytesize API](https://github.com/flang-project/bytesize/pull/9) in order to fix [a design flaw](https://github.com/flang-project/bytesize/issues/7), and since you're the only pubic crate using bytesize at the moment and the rewrite didn't seem too hard I thought I'd drop you an MR with the required changes.

This is only the minimum changeset required for ByteSize-related code to compile again. I have left some usages of usize in the code in places where I wasn't sure which semantics were desired. I encourage you to take a look at them, as you may be vulnerable to the same kind of u32 overflow as bytesize was.

**Please do not merge this yet, as bytesize v0.2 has not been released at this point in time (2017-09-21).**

