### PR TITLE
Implements Windows uptime retrieval

### DIFF
--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -4,6 +4,7 @@ use kernel32;
 use std::{io, path, mem};
 use data::*;
 use super::common::*;
+use kernel32::GetTickCount64;
 
 pub struct PlatformImpl;
 
@@ -54,7 +55,8 @@ impl Platform for PlatformImpl {
     }
 
     fn uptime(&self) -> io::Result<Duration> {
-        Err(io::Error::new(io::ErrorKind::Other, "Not supported"))
+        let since_boot: u64 = unsafe { GetTickCount64() };
+        Ok(Duration::from_millis(since_boot))
     }
 
     fn battery_life(&self) -> io::Result<BatteryLife> {


### PR DESCRIPTION
Theoretically, this should work according to the research I conducted in filing #15. However, I have not tested it as I do not have a Windows machine accessible at the moment. I can however confirm that it does build using the `x86_64-pc-windows-gnu` target. It should probably be tested on a Windows machine…

Closes #15