### PR TITLE
Use uptime_lib for retrieving uptime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ time = "0.1"
 chrono = "0.4"
 lazy_static = "0.2"
 bytesize = "0.1"
+uptime_lib = "0.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 nom = "3.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,10 @@ extern crate lazy_static;
 #[macro_use]
 extern crate nom;
 
+#[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos",
+            target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))]
+extern crate uptime_lib;
+
 pub mod platform;
 pub mod data;
 

--- a/src/platform/common.rs
+++ b/src/platform/common.rs
@@ -1,6 +1,7 @@
 use std::{io, path};
 use time;
 use data::*;
+use uptime_lib;
 
 /// The Platform trait declares all the functions for getting system information.
 pub trait Platform {
@@ -35,11 +36,12 @@ pub trait Platform {
 
     /// Returns the system uptime.
     fn uptime(&self) -> io::Result<Duration> {
-        self.boot_time().and_then(|bt| {
-            time::Duration::to_std(&Utc::now().signed_duration_since(bt)).map_err(|e| {
-                io::Error::new(io::ErrorKind::Other, "Could not process time")
-            })
-        })
+        match uptime_lib::get() {
+            Ok(uptime) => Ok(uptime.to_std().expect(
+                "Unexpected impossible time less than zero",
+            )),
+            Err(err) => Err(io::Error::new(io::ErrorKind::Other, err)),
+        }
     }
 
     /// Returns the system boot time.

--- a/src/platform/common.rs
+++ b/src/platform/common.rs
@@ -18,12 +18,13 @@ pub trait Platform {
     /// `DelayedMeasurement` with `.done()`.
     fn cpu_load_aggregate(&self) -> io::Result<DelayedMeasurement<CPULoad>> {
         let measurement = try!(self.cpu_load());
-        Ok(DelayedMeasurement::new(
-                Box::new(move || measurement.done().map(|ls| {
+        Ok(DelayedMeasurement::new(Box::new(move || {
+            measurement.done().map(|ls| {
                     let mut it = ls.iter();
                     let first = it.next().unwrap().clone(); // has to be a variable, rust moves the iterator otherwise
                     it.fold(first, |acc, l| acc.avg_add(l))
-                }))))
+                })
+        })))
     }
 
     /// Returns a load average object.
@@ -35,16 +36,21 @@ pub trait Platform {
     /// Returns the system uptime.
     fn uptime(&self) -> io::Result<Duration> {
         self.boot_time().and_then(|bt| {
-            time::Duration::to_std(&Utc::now().signed_duration_since(bt))
-                .map_err(|e| io::Error::new(io::ErrorKind::Other, "Could not process time"))
+            time::Duration::to_std(&Utc::now().signed_duration_since(bt)).map_err(|e| {
+                io::Error::new(io::ErrorKind::Other, "Could not process time")
+            })
         })
     }
 
     /// Returns the system boot time.
     fn boot_time(&self) -> io::Result<DateTime<Utc>> {
         self.uptime().and_then(|ut| {
-            Ok(Utc::now() - try!(time::Duration::from_std(ut)
-                .map_err(|e| io::Error::new(io::ErrorKind::Other, "Could not process time"))))
+            Ok(
+                Utc::now() -
+                    try!(time::Duration::from_std(ut).map_err(|e| {
+                        io::Error::new(io::ErrorKind::Other, "Could not process time")
+                    })),
+            )
         })
     }
 

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -23,8 +23,10 @@ fn value_from_file(path: &str) -> io::Result<i32> {
         .parse()
         .and_then(|n| Ok(n))
         .or_else(|_| {
-            Err(io::Error::new(io::ErrorKind::Other,
-                               format!("File: \"{}\" doesn't contain an int value", &path)))
+            Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!("File: \"{}\" doesn't contain an int value", &path),
+            ))
         })
 }
 
@@ -36,9 +38,10 @@ fn time(on_ac: bool, charge_full: i32, charge_now: i32, current_now: i32) -> Dur
     if current_now != 0 {
         if on_ac {
             // Charge time
-            Duration::from_secs((charge_full - charge_now).abs() as u64 * 3600u64 / current_now as u64)
-        }
-        else {
+            Duration::from_secs(
+                (charge_full - charge_now).abs() as u64 * 3600u64 / current_now as u64,
+            )
+        } else {
             // Discharge time
             Duration::from_secs(charge_now as u64 * 3600u64 / current_now as u64)
         }
@@ -307,17 +310,19 @@ impl Platform for PlatformImpl {
             }
         }
         if full != 0 {
-            let on_ac =
-                match self.on_ac_power() {
-                    Ok(true) => true,
-                    _ => false,
-                };
+            let on_ac = match self.on_ac_power() {
+                Ok(true) => true,
+                _ => false,
+            };
             Ok(BatteryLife {
                 remaining_capacity: capacity(full, now),
                 remaining_time: time(on_ac, full, now, current),
             })
         } else {
-            Err(io::Error::new(io::ErrorKind::Other, "Missing battery information"))
+            Err(io::Error::new(
+                io::ErrorKind::Other,
+                "Missing battery information",
+            ))
         }
     }
 
@@ -364,7 +369,10 @@ impl Platform for PlatformImpl {
         read_file("/sys/class/thermal/thermal_zone0/temp")
             .and_then(|data| match data.parse::<f32>() {
                 Ok(x) => Ok(x),
-                Err(_) => Err(io::Error::new(io::ErrorKind::Other, "Could not parse float")),
+                Err(_) => Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    "Could not parse float",
+                )),
             })
             .map(|num| num / 1000.0)
     }

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -282,12 +282,6 @@ impl Platform for PlatformImpl {
             })
     }
 
-    fn uptime(&self) -> io::Result<Duration> {
-        let mut info: sysinfo = unsafe { mem::zeroed() };
-        unsafe { sysinfo(&mut info) };
-        Ok(Duration::from_secs(info.uptime as u64))
-    }
-
     fn battery_life(&self) -> io::Result<BatteryLife> {
         let dir = "/sys/class/power_supply";
         let entries = try!(fs::read_dir(&dir));

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -83,7 +83,13 @@ mod tests {
     fn test_mounts() {
         let mounts = PlatformImpl::new().mounts().unwrap();
         assert!(mounts.len() > 0);
-        assert!(mounts.iter().find(|m| m.fs_mounted_on == "/").unwrap().fs_mounted_on == "/");
+        assert!(
+            mounts
+                .iter()
+                .find(|m| m.fs_mounted_on == "/")
+                .unwrap()
+                .fs_mounted_on == "/"
+        );
     }
 
     #[test]
@@ -95,7 +101,14 @@ mod tests {
     #[test]
     fn test_networks() {
         let networks = PlatformImpl::new().networks().unwrap();
-        assert!(networks.values().find(|n| n.name == "lo0").unwrap().addrs.len() > 0);
+        assert!(
+            networks
+                .values()
+                .find(|n| n.name == "lo0")
+                .unwrap()
+                .addrs
+                .len() > 0
+        );
     }
 
 }

--- a/src/platform/openbsd.rs
+++ b/src/platform/openbsd.rs
@@ -46,11 +46,15 @@ impl Platform for PlatformImpl {
 
     fn cpu_load(&self) -> io::Result<DelayedMeasurement<Vec<CPULoad>>> {
         let loads = try!(measure_cpu());
-        Ok(DelayedMeasurement::new(
-                Box::new(move || Ok(loads.iter()
-                               .zip(try!(measure_cpu()).iter())
-                               .map(|(prev, now)| (*now - prev).to_cpuload())
-                               .collect::<Vec<_>>()))))
+        Ok(DelayedMeasurement::new(Box::new(move || {
+            Ok(
+                loads
+                    .iter()
+                    .zip(try!(measure_cpu()).iter())
+                    .map(|(prev, now)| (*now - prev).to_cpuload())
+                    .collect::<Vec<_>>(),
+            )
+        })))
     }
 
     fn load_average(&self) -> io::Result<LoadAverage> {
@@ -58,8 +62,14 @@ impl Platform for PlatformImpl {
     }
 
     fn memory(&self) -> io::Result<Memory> {
-        let mut uvm_info = uvmexp::default(); sysctl!(VM_UVMEXP, &mut uvm_info, mem::size_of::<uvmexp>());
-        let mut bcache_info = bcachestats::default(); sysctl!(VFS_BCACHESTAT, &mut bcache_info, mem::size_of::<bcachestats>());
+        let mut uvm_info = uvmexp::default();
+        sysctl!(VM_UVMEXP, &mut uvm_info, mem::size_of::<uvmexp>());
+        let mut bcache_info = bcachestats::default();
+        sysctl!(
+            VFS_BCACHESTAT,
+            &mut bcache_info,
+            mem::size_of::<bcachestats>()
+        );
         let total = ByteSize::kib((uvm_info.npages << *bsd::PAGESHIFT) as usize);
         let pmem = PlatformMemory {
             active: ByteSize::kib((uvm_info.active << *bsd::PAGESHIFT) as usize),
@@ -79,7 +89,13 @@ impl Platform for PlatformImpl {
     fn boot_time(&self) -> io::Result<DateTime<Utc>> {
         let mut data: timeval = unsafe { mem::zeroed() };
         sysctl!(KERN_BOOTTIME, &mut data, mem::size_of::<timeval>());
-        Ok(DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(data.tv_sec, data.tv_usec as u32), Utc))
+        Ok(DateTime::<Utc>::from_utc(
+            NaiveDateTime::from_timestamp(
+                data.tv_sec,
+                data.tv_usec as u32,
+            ),
+            Utc,
+        ))
     }
 
     // /dev/apm is probably the nicest interface I've seen :)
@@ -87,13 +103,18 @@ impl Platform for PlatformImpl {
         let f = try!(fs::File::open("/dev/apm"));
         let mut info = apm_power_info::default();
         if unsafe { ioctl(f.as_raw_fd(), *APM_IOC_GETPOWER, &mut info) } == -1 {
-            return Err(io::Error::new(io::ErrorKind::Other, "ioctl() failed"))
+            return Err(io::Error::new(io::ErrorKind::Other, "ioctl() failed"));
         }
-        if info.battery_state == 0xff { // APM_BATT_UNKNOWN
-            return Err(io::Error::new(io::ErrorKind::Other, "Battery state unknown"))
+        if info.battery_state == 0xff {
+            // APM_BATT_UNKNOWN
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "Battery state unknown",
+            ));
         }
-        if info.battery_state == 4 { // APM_BATTERY_ABSENT
-            return Err(io::Error::new(io::ErrorKind::Other, "Battery absent"))
+        if info.battery_state == 4 {
+            // APM_BATTERY_ABSENT
+            return Err(io::Error::new(io::ErrorKind::Other, "Battery absent"));
         }
         Ok(BatteryLife {
             remaining_capacity: info.battery_life as f32,
@@ -105,7 +126,7 @@ impl Platform for PlatformImpl {
         let f = try!(fs::File::open("/dev/apm"));
         let mut info = apm_power_info::default();
         if unsafe { ioctl(f.as_raw_fd(), *APM_IOC_GETPOWER, &mut info) } == -1 {
-            return Err(io::Error::new(io::ErrorKind::Other, "ioctl() failed"))
+            return Err(io::Error::new(io::ErrorKind::Other, "ioctl() failed"));
         }
         Ok(info.ac_state == 0x01) // APM_AC_ON
     }
@@ -154,132 +175,132 @@ struct apm_power_info {
 #[derive(Default, Debug)]
 #[repr(C)]
 struct bcachestats {
-    numbufs: i64,		/* number of buffers allocated */
-    numbufpages: i64,		/* number of pages in buffer cache */
-    numdirtypages: i64, 		/* number of dirty free pages */
-    numcleanpages: i64, 		/* number of clean free pages */
-    pendingwrites: i64,		/* number of pending writes */
-    pendingreads: i64,		/* number of pending reads */
-    numwrites: i64,		/* total writes started */
-    numreads: i64,		/* total reads started */
-    cachehits: i64,		/* total reads found in cache */
-    busymapped: i64,		/* number of busy and mapped buffers */
-    dmapages: i64,		/* dma reachable pages in buffer cache */
-    highpages: i64,		/* pages above dma region */
-    delwribufs: i64,		/* delayed write buffers */
-    kvaslots: i64,		/* kva slots total */
-    kvaslots_avail: i64,		/* available kva slots */
-    highflips: i64,		/* total flips to above DMA */
-    highflops: i64,		/* total failed flips to above DMA */
-    dmaflips: i64,		/* total flips from high to DMA */
+    numbufs: i64, /* number of buffers allocated */
+    numbufpages: i64, /* number of pages in buffer cache */
+    numdirtypages: i64, /* number of dirty free pages */
+    numcleanpages: i64, /* number of clean free pages */
+    pendingwrites: i64, /* number of pending writes */
+    pendingreads: i64, /* number of pending reads */
+    numwrites: i64, /* total writes started */
+    numreads: i64, /* total reads started */
+    cachehits: i64, /* total reads found in cache */
+    busymapped: i64, /* number of busy and mapped buffers */
+    dmapages: i64, /* dma reachable pages in buffer cache */
+    highpages: i64, /* pages above dma region */
+    delwribufs: i64, /* delayed write buffers */
+    kvaslots: i64, /* kva slots total */
+    kvaslots_avail: i64, /* available kva slots */
+    highflips: i64, /* total flips to above DMA */
+    highflops: i64, /* total failed flips to above DMA */
+    dmaflips: i64, /* total flips from high to DMA */
 }
 
 #[derive(Default, Debug)]
 #[repr(C)]
 struct uvmexp {
     /* vm_page constants */
-    pagesize: c_int,   /* size of a page (PAGE_SIZE): must be power of 2 */
-    pagemask: c_int,   /* page mask */
-    pageshift: c_int,  /* page shift */
+    pagesize: c_int, /* size of a page (PAGE_SIZE): must be power of 2 */
+    pagemask: c_int, /* page mask */
+    pageshift: c_int, /* page shift */
 
     /* vm_page counters */
-    npages: c_int,     /* number of pages we manage */
-    free: c_int,       /* number of free pages */
-    active: c_int,     /* number of active pages */
-    inactive: c_int,   /* number of pages that we free'd but may want back */
-    paging: c_int,	/* number of pages in the process of being paged out */
-    wired: c_int,      /* number of wired pages */
+    npages: c_int, /* number of pages we manage */
+    free: c_int, /* number of free pages */
+    active: c_int, /* number of active pages */
+    inactive: c_int, /* number of pages that we free'd but may want back */
+    paging: c_int, /* number of pages in the process of being paged out */
+    wired: c_int, /* number of wired pages */
 
-    zeropages: c_int,		/* number of zero'd pages */
+    zeropages: c_int, /* number of zero'd pages */
     reserve_pagedaemon: c_int, /* number of pages reserved for pagedaemon */
-    reserve_kernel: c_int,	/* number of pages reserved for kernel */
-    anonpages: c_int,		/* number of pages used by anon pagers */
-    vnodepages: c_int,		/* number of pages used by vnode page cache */
-    vtextpages: c_int,		/* number of pages used by vtext vnodes */
+    reserve_kernel: c_int, /* number of pages reserved for kernel */
+    anonpages: c_int, /* number of pages used by anon pagers */
+    vnodepages: c_int, /* number of pages used by vnode page cache */
+    vtextpages: c_int, /* number of pages used by vtext vnodes */
 
     /* pageout params */
-    freemin: c_int,    /* min number of free pages */
-    freetarg: c_int,   /* target number of free pages */
-    inactarg: c_int,   /* target number of inactive pages */
-    wiredmax: c_int,   /* max number of wired pages */
-    anonmin: c_int,	/* min threshold for anon pages */
-    vtextmin: c_int,	/* min threshold for vtext pages */
-    vnodemin: c_int,	/* min threshold for vnode pages */
-    anonminpct: c_int,	/* min percent anon pages */
-    vtextminpct: c_int,/* min percent vtext pages */
-    vnodeminpct: c_int,/* min percent vnode pages */
+    freemin: c_int, /* min number of free pages */
+    freetarg: c_int, /* target number of free pages */
+    inactarg: c_int, /* target number of inactive pages */
+    wiredmax: c_int, /* max number of wired pages */
+    anonmin: c_int, /* min threshold for anon pages */
+    vtextmin: c_int, /* min threshold for vtext pages */
+    vnodemin: c_int, /* min threshold for vnode pages */
+    anonminpct: c_int, /* min percent anon pages */
+    vtextminpct: c_int, /* min percent vtext pages */
+    vnodeminpct: c_int, /* min percent vnode pages */
 
     /* swap */
-    nswapdev: c_int,	/* number of configured swap devices in system */
-    swpages: c_int,	/* number of PAGE_SIZE'ed swap pages */
-    swpginuse: c_int,	/* number of swap pages in use */
-    swpgonly: c_int,	/* number of swap pages in use, not also in RAM */
-    nswget: c_int,	/* number of times fault calls uvm_swap_get() */
-    nanon: c_int,	/* number total of anon's in system */
-    nanonneeded: c_int,/* number of anons currently needed */
-    nfreeanon: c_int,	/* number of free anon's */
+    nswapdev: c_int, /* number of configured swap devices in system */
+    swpages: c_int, /* number of PAGE_SIZE'ed swap pages */
+    swpginuse: c_int, /* number of swap pages in use */
+    swpgonly: c_int, /* number of swap pages in use, not also in RAM */
+    nswget: c_int, /* number of times fault calls uvm_swap_get() */
+    nanon: c_int, /* number total of anon's in system */
+    nanonneeded: c_int, /* number of anons currently needed */
+    nfreeanon: c_int, /* number of free anon's */
 
     /* stat counters */
-    faults: c_int,		/* page fault count */
-    traps: c_int,		/* trap count */
-    intrs: c_int,		/* interrupt count */
-    swtch: c_int,		/* context switch count */
-    softs: c_int,		/* software interrupt count */
-    syscalls: c_int,		/* system calls */
-    pageins: c_int,		/* pagein operation count */
+    faults: c_int, /* page fault count */
+    traps: c_int, /* trap count */
+    intrs: c_int, /* interrupt count */
+    swtch: c_int, /* context switch count */
+    softs: c_int, /* software interrupt count */
+    syscalls: c_int, /* system calls */
+    pageins: c_int, /* pagein operation count */
     /* pageouts are in pdpageouts below */
-    obsolete_swapins: c_int,	/* swapins */
-    obsolete_swapouts: c_int,	/* swapouts */
-    pgswapin: c_int,		/* pages swapped in */
-    pgswapout: c_int,		/* pages swapped out */
-    forks: c_int,  		/* forks */
-    forks_ppwait: c_int,	/* forks where parent waits */
-    forks_sharevm: c_int,	/* forks where vmspace is shared */
-    pga_zerohit: c_int,	/* pagealloc where zero wanted and zero
+    obsolete_swapins: c_int, /* swapins */
+    obsolete_swapouts: c_int, /* swapouts */
+    pgswapin: c_int, /* pages swapped in */
+    pgswapout: c_int, /* pages swapped out */
+    forks: c_int, /* forks */
+    forks_ppwait: c_int, /* forks where parent waits */
+    forks_sharevm: c_int, /* forks where vmspace is shared */
+    pga_zerohit: c_int, /* pagealloc where zero wanted and zero
                            was available */
-    pga_zeromiss: c_int,	/* pagealloc where zero wanted and zero
+    pga_zeromiss: c_int, /* pagealloc where zero wanted and zero
                                not available */
-    zeroaborts: c_int,		/* number of times page zeroing was
+    zeroaborts: c_int, /* number of times page zeroing was
                                aborted */
 
     /* fault subcounters */
-    fltnoram: c_int,	/* number of times fault was out of ram */
-    fltnoanon: c_int,	/* number of times fault was out of anons */
-    fltnoamap: c_int,	/* number of times fault was out of amap chunks */
-    fltpgwait: c_int,	/* number of times fault had to wait on a page */
-    fltpgrele: c_int,	/* number of times fault found a released page */
-    fltrelck: c_int,	/* number of times fault relock called */
-    fltrelckok: c_int,	/* number of times fault relock is a success */
-    fltanget: c_int,	/* number of times fault gets anon page */
-    fltanretry: c_int,	/* number of times fault retrys an anon get */
-    fltamcopy: c_int,	/* number of times fault clears "needs copy" */
-    fltnamap: c_int,	/* number of times fault maps a neighbor anon page */
-    fltnomap: c_int,	/* number of times fault maps a neighbor obj page */
-    fltlget: c_int,	/* number of times fault does a locked pgo_get */
-    fltget: c_int,	/* number of times fault does an unlocked get */
-    flt_anon: c_int,	/* number of times fault anon (case 1a) */
-    flt_acow: c_int,	/* number of times fault anon cow (case 1b) */
-    flt_obj: c_int,	/* number of times fault is on object page (2a) */
-    flt_prcopy: c_int,	/* number of times fault promotes with copy (2b) */
-    flt_przero: c_int,	/* number of times fault promotes with zerofill (2b) */
+    fltnoram: c_int, /* number of times fault was out of ram */
+    fltnoanon: c_int, /* number of times fault was out of anons */
+    fltnoamap: c_int, /* number of times fault was out of amap chunks */
+    fltpgwait: c_int, /* number of times fault had to wait on a page */
+    fltpgrele: c_int, /* number of times fault found a released page */
+    fltrelck: c_int, /* number of times fault relock called */
+    fltrelckok: c_int, /* number of times fault relock is a success */
+    fltanget: c_int, /* number of times fault gets anon page */
+    fltanretry: c_int, /* number of times fault retrys an anon get */
+    fltamcopy: c_int, /* number of times fault clears "needs copy" */
+    fltnamap: c_int, /* number of times fault maps a neighbor anon page */
+    fltnomap: c_int, /* number of times fault maps a neighbor obj page */
+    fltlget: c_int, /* number of times fault does a locked pgo_get */
+    fltget: c_int, /* number of times fault does an unlocked get */
+    flt_anon: c_int, /* number of times fault anon (case 1a) */
+    flt_acow: c_int, /* number of times fault anon cow (case 1b) */
+    flt_obj: c_int, /* number of times fault is on object page (2a) */
+    flt_prcopy: c_int, /* number of times fault promotes with copy (2b) */
+    flt_przero: c_int, /* number of times fault promotes with zerofill (2b) */
 
     /* daemon counters */
-    pdwoke: c_int,	/* number of times daemon woke up */
-    pdrevs: c_int,	/* number of times daemon rev'd clock hand */
-    pdswout: c_int,	/* number of times daemon called for swapout */
-    pdfreed: c_int,	/* number of pages daemon freed since boot */
-    pdscans: c_int,	/* number of pages daemon scanned since boot */
-    pdanscan: c_int,	/* number of anonymous pages scanned by daemon */
-    pdobscan: c_int,	/* number of object pages scanned by daemon */
-    pdreact: c_int,	/* number of pages daemon reactivated since boot */
-    pdbusy: c_int,	/* number of times daemon found a busy page */
-    pdpageouts: c_int,	/* number of times daemon started a pageout */
-    pdpending: c_int,	/* number of times daemon got a pending pagout */
-    pddeact: c_int,	/* number of pages daemon deactivates */
-    pdreanon: c_int,	/* anon pages reactivated due to min threshold */
-    pdrevnode: c_int,	/* vnode pages reactivated due to min threshold */
-    pdrevtext: c_int,	/* vtext pages reactivated due to min threshold */
+    pdwoke: c_int, /* number of times daemon woke up */
+    pdrevs: c_int, /* number of times daemon rev'd clock hand */
+    pdswout: c_int, /* number of times daemon called for swapout */
+    pdfreed: c_int, /* number of pages daemon freed since boot */
+    pdscans: c_int, /* number of pages daemon scanned since boot */
+    pdanscan: c_int, /* number of anonymous pages scanned by daemon */
+    pdobscan: c_int, /* number of object pages scanned by daemon */
+    pdreact: c_int, /* number of pages daemon reactivated since boot */
+    pdbusy: c_int, /* number of times daemon found a busy page */
+    pdpageouts: c_int, /* number of times daemon started a pageout */
+    pdpending: c_int, /* number of times daemon got a pending pagout */
+    pddeact: c_int, /* number of pages daemon deactivates */
+    pdreanon: c_int, /* anon pages reactivated due to min threshold */
+    pdrevnode: c_int, /* vnode pages reactivated due to min threshold */
+    pdrevtext: c_int, /* vtext pages reactivated due to min threshold */
 
-    fpswtch: c_int,	/* FPU context switches */
-    kmapent: c_int,	/* number of kernel map entries */
+    fpswtch: c_int, /* FPU context switches */
+    kmapent: c_int, /* number of kernel map entries */
 }

--- a/src/platform/unix.rs
+++ b/src/platform/unix.rs
@@ -5,25 +5,29 @@ use data::*;
 pub fn load_average() -> io::Result<LoadAverage> {
     let mut loads: [f64; 3] = [0.0, 0.0, 0.0];
     if unsafe { getloadavg(&mut loads[0], 3) } != 3 {
-        return Err(io::Error::new(io::ErrorKind::Other, "getloadavg() failed"))
+        return Err(io::Error::new(io::ErrorKind::Other, "getloadavg() failed"));
     }
     Ok(LoadAverage {
         one: loads[0] as f32,
         five: loads[1] as f32,
-        fifteen: loads[2] as f32
+        fifteen: loads[2] as f32,
     })
 }
 
 pub fn networks() -> io::Result<BTreeMap<String, Network>> {
     let mut ifap: *mut ifaddrs = ptr::null_mut();
     if unsafe { getifaddrs(&mut ifap) } != 0 {
-        return Err(io::Error::new(io::ErrorKind::Other, "getifaddrs() failed"))
+        return Err(io::Error::new(io::ErrorKind::Other, "getifaddrs() failed"));
     }
     let ifirst = ifap;
     let mut result = BTreeMap::new();
     while ifap != ptr::null_mut() {
         let ifa = unsafe { (*ifap) };
-        let name = unsafe { ffi::CStr::from_ptr(ifa.ifa_name).to_string_lossy().into_owned() };
+        let name = unsafe {
+            ffi::CStr::from_ptr(ifa.ifa_name)
+                .to_string_lossy()
+                .into_owned()
+        };
         let mut entry = result.entry(name.clone()).or_insert(Network {
             name: name,
             addrs: Vec::new(),
@@ -47,16 +51,29 @@ fn parse_addr(aptr: *const sockaddr) -> IpAddr {
     }
     let addr = unsafe { *aptr };
     match addr.sa_family as i32 {
-        AF_INET => IpAddr::V4(Ipv4Addr::new(addr.sa_data[2] as u8, addr.sa_data[3] as u8,
-                                            addr.sa_data[4] as u8, addr.sa_data[5] as u8)),
+        AF_INET => IpAddr::V4(Ipv4Addr::new(
+            addr.sa_data[2] as u8,
+            addr.sa_data[3] as u8,
+            addr.sa_data[4] as u8,
+            addr.sa_data[5] as u8,
+        )),
         AF_INET6 => {
             // This is horrible.
             let addr6: *const sockaddr_in6 = unsafe { mem::transmute(aptr) };
             let mut a: [u8; 16] = unsafe { (*addr6).sin6_addr.s6_addr };
             &mut a[..].reverse();
             let a: [u16; 8] = unsafe { mem::transmute(a) };
-            IpAddr::V6(Ipv6Addr::new(a[7], a[6], a[5], a[4], a[3], a[2], a[1], a[0]))
-        },
+            IpAddr::V6(Ipv6Addr::new(
+                a[7],
+                a[6],
+                a[5],
+                a[4],
+                a[3],
+                a[2],
+                a[1],
+                a[0],
+            ))
+        }
         _ => IpAddr::Unsupported,
     }
 }

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -55,10 +55,6 @@ impl Platform for PlatformImpl {
         })
     }
 
-    fn uptime(&self) -> io::Result<Duration> {
-        Err(io::Error::new(io::ErrorKind::Other, "Not supported"))
-    }
-
     fn battery_life(&self) -> io::Result<BatteryLife> {
         let status = power_status();
         if status.BatteryFlag == 128 {

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -35,7 +35,9 @@ impl Platform for PlatformImpl {
             ullAvailVirtual: 0,
             ullAvailExtendedVirtual: 0,
         };
-        unsafe { kernel32::GlobalMemoryStatusEx(&mut status); }
+        unsafe {
+            kernel32::GlobalMemoryStatusEx(&mut status);
+        }
         let pm = PlatformMemory {
             load: status.dwMemoryLoad,
             total_phys: ByteSize::b(status.ullTotalPhys as usize),
@@ -60,10 +62,13 @@ impl Platform for PlatformImpl {
     fn battery_life(&self) -> io::Result<BatteryLife> {
         let status = power_status();
         if status.BatteryFlag == 128 {
-            return Err(io::Error::new(io::ErrorKind::Other, "Battery absent"))
+            return Err(io::Error::new(io::ErrorKind::Other, "Battery absent"));
         }
         if status.BatteryFlag == 255 {
-            return Err(io::Error::new(io::ErrorKind::Other, "Battery status unknown"))
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "Battery status unknown",
+            ));
         }
         Ok(BatteryLife {
             remaining_capacity: status.BatteryLifePercent as f32 / 100.0,
@@ -101,6 +106,8 @@ fn power_status() -> winbase::SYSTEM_POWER_STATUS {
         BatteryLifeTime: 0,
         BatteryFullLifeTime: 0,
     };
-    unsafe { kernel32::GetSystemPowerStatus(&mut status); }
+    unsafe {
+        kernel32::GetSystemPowerStatus(&mut status);
+    }
     status
 }


### PR DESCRIPTION
This supercedes #16 as it is a better choice to use `uptime_lib` instead of doing the same logic inside of `systemstat`.

Closes #15