### PR TITLE
Network stats

### DIFF
--- a/examples/info.rs
+++ b/examples/info.rs
@@ -28,6 +28,16 @@ fn main() {
         Err(x) => println!("\nNetworks: error: {}", x)
     }
 
+    match sys.networks() {
+        Ok(netifs) => {
+            println!("\nNetwork interface statistics:");
+            for netif in netifs.values() {
+                println!("{} statistics: ({:?})", netif.name, sys.network_stats(&netif.name));
+            }
+        }
+        Err(x) => println!("\nNetworks: error: {}", x)
+    }
+
     match sys.battery_life() {
         Ok(battery) =>
             print!("\nBattery: {}%, {}h{}m remaining",

--- a/src/data.rs
+++ b/src/data.rs
@@ -195,10 +195,10 @@ pub struct Network {
 
 #[derive(Debug, Clone)]
 pub struct NetworkStats {
-    pub rx_bytes: u64,
-    pub tx_bytes: u64,
-    pub rx_packets: u64,
-    pub tx_packets: u64,
-    pub rx_errors: u64,
-    pub tx_errors: u64,
+    pub rx_bytes: usize,
+    pub tx_bytes: usize,
+    pub rx_packets: usize,
+    pub tx_packets: usize,
+    pub rx_errors: usize,
+    pub tx_errors: usize,
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -192,3 +192,13 @@ pub struct Network {
     pub name: String,
     pub addrs: Vec<NetworkAddrs>,
 }
+
+#[derive(Debug, Clone)]
+pub struct NetworkStats {
+    pub rx_bytes: u64,
+    pub tx_bytes: u64,
+    pub rx_packets: u64,
+    pub tx_packets: u64,
+    pub rx_errors: u64,
+    pub tx_errors: u64,
+}

--- a/src/platform/common.rs
+++ b/src/platform/common.rs
@@ -67,6 +67,9 @@ pub trait Platform {
     /// interface. You can use the .values() iterator if you need to iterate over all of them.
     fn networks(&self) -> io::Result<BTreeMap<String, Network>>;
 
+    /// Returns statistics for a given interface (bytes/packets sent/received)
+    fn network_stats(&self, interface: &str) -> io::Result<NetworkStats>;
+
     /// Returns the current CPU temperature in degrees Celsius.
     ///
     /// Depending on the platform, this might be core 0, package, etc.

--- a/src/platform/freebsd.rs
+++ b/src/platform/freebsd.rs
@@ -158,6 +158,10 @@ fn measure_cpu() -> io::Result<Vec<CpuTime>> {
     let cpus = *CP_TIMES_SIZE / mem::size_of::<bsd::sysctl_cpu>();
     let mut data: Vec<bsd::sysctl_cpu> = Vec::with_capacity(cpus);
     unsafe { data.set_len(cpus) };
+    fn network_stats(&self, interface: &str) -> io::Result<NetworkStats> {
+        Err(io::Error::new(io::ErrorKind::Other, "Not supported"))
+    }
+
     sysctl!(KERN_CP_TIMES, &mut data[0], *CP_TIMES_SIZE);
     Ok(data.into_iter().map(|cpu| cpu.into()).collect())
 }

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -370,12 +370,12 @@ impl Platform for PlatformImpl {
         let path_root: String = ("/sys/class/net/".to_string() + interface) + "/statistics/";
         let stats_file = |file: &str| (&path_root).to_string() + file;
 
-        let rx_bytes: u64 = try!(value_from_file::<u64>(&stats_file("rx_bytes")));
-        let tx_bytes: u64 = try!(value_from_file::<u64>(&stats_file("tx_bytes")));
-        let rx_packets: u64 = try!(value_from_file::<u64>(&stats_file("rx_packets")));
-        let tx_packets: u64 = try!(value_from_file::<u64>(&stats_file("tx_packets")));
-        let rx_errors: u64 = try!(value_from_file::<u64>(&stats_file("rx_errors")));
-        let tx_errors: u64 = try!(value_from_file::<u64>(&stats_file("tx_errors")));
+        let rx_bytes: usize = try!(value_from_file::<usize>(&stats_file("rx_bytes")));
+        let tx_bytes: usize = try!(value_from_file::<usize>(&stats_file("tx_bytes")));
+        let rx_packets: usize = try!(value_from_file::<usize>(&stats_file("rx_packets")));
+        let tx_packets: usize = try!(value_from_file::<usize>(&stats_file("tx_packets")));
+        let rx_errors: usize = try!(value_from_file::<usize>(&stats_file("rx_errors")));
+        let tx_errors: usize = try!(value_from_file::<usize>(&stats_file("tx_errors")));
 
         Ok(NetworkStats {
             rx_bytes,

--- a/src/platform/openbsd.rs
+++ b/src/platform/openbsd.rs
@@ -138,6 +138,10 @@ fn measure_cpu() -> io::Result<Vec<CpuTime>> {
         sysctl!(mib, &mut data[i], mem::size_of::<bsd::sysctl_cpu>());
     }
     Ok(data.into_iter().map(|cpu| cpu.into()).collect())
+    fn network_stats(&self, interface: &str) -> io::Result<NetworkStats> {
+        Err(io::Error::new(io::ErrorKind::Other, "Not supported"))
+    }
+
 }
 
 #[derive(Default, Debug)]

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -94,6 +94,10 @@ impl Platform for PlatformImpl {
     }
 }
 
+    fn network_stats(&self, interface: &str) -> io::Result<NetworkStats> {
+        Err(io::Error::new(io::ErrorKind::Other, "Not supported"))
+    }
+
 fn power_status() -> winbase::SYSTEM_POWER_STATUS {
     let mut status = winbase::SYSTEM_POWER_STATUS {
         ACLineStatus: 0,


### PR DESCRIPTION
Added basic network interface stats for linux (addresses issue #18 for linux)

My editor does `rustfmt` automatically on save, which I forgot about until after I'd committed a bunch - let me know if these changes are an issue and I can filter them down to just the core changes which I've made.

I've made 3 changes:

- linux.rs: `value_from_file` is now generic over it's (wrapped) return type, modulo a `FromStr` instance. This is because I wanted to use this function to parse `usize` as well as `i32`. I updated all previous references with type hints for `i32` to retain compatibility.

- The `Platform` trait now has a `network_stats` function, which takes an interface name as an argument.  This returns a `NetworkStats` struct containing
    - received bytes
    - received packets
    - transmitted bytes
    - transmitted packets
    - receive errors
    - transmission errors

- Added an implementation for each platform type. These all error with "Not supported" with the exception of linux. The linux implementation reads the appropriate files from sysfs.

I've marked this WIP because I'm just checking these are all the statistics I need.

Tested live with a simple test harness I made to read stats for all interfaces on my system. The integration tests don't pass reliably on my system (they look like they're intended for BSD), but also don't seem to have changed in behaviour with these changes.

All the best,
Richard