### PR TITLE
Add block device statistics (linux)

### DIFF
--- a/examples/info.rs
+++ b/examples/info.rs
@@ -18,6 +18,15 @@ fn main() {
         Err(x) => println!("\nMounts: error: {}", x)
     }
 
+    match sys.block_device_statistics() {
+        Ok(stats) => {
+            for blkstats in stats.values() {
+                println!("{}: {:?}", blkstats.name, blkstats);
+            }
+        }
+        Err(x) => println!("Block statistics error: {}", x.to_string())
+    }
+
     match sys.networks() {
         Ok(netifs) => {
             println!("\nNetworks:");

--- a/src/data.rs
+++ b/src/data.rs
@@ -197,6 +197,7 @@ pub type Disk = String;
 
 #[derive(Debug, Clone)]
 pub struct BlockDeviceStats {
+    pub name: String,
     pub read_ios: u64,
     pub read_merges: u64,
     pub read_sectors: u64,

--- a/src/data.rs
+++ b/src/data.rs
@@ -192,3 +192,20 @@ pub struct Network {
     pub name: String,
     pub addrs: Vec<NetworkAddrs>,
 }
+
+pub type Disk = String;
+
+#[derive(Debug, Clone)]
+pub struct BlockDeviceStats {
+    read_ios: u64,
+    read_merges: u64,
+    read_sectors: u64,
+    read_ticks: u64,
+    write_ios: u64,
+    write_merges: u64,
+    write_sectors: u64,
+    write_ticks: u64,
+    in_flight: u64,
+    io_ticks: u64,
+    time_in_queue: u64
+}

--- a/src/data.rs
+++ b/src/data.rs
@@ -176,17 +176,17 @@ pub struct Filesystem {
 #[derive(Debug, Clone)]
 pub struct BlockDeviceStats {
     pub name: String,
-    pub read_ios: u64,
-    pub read_merges: u64,
-    pub read_sectors: u64,
-    pub read_ticks: u64,
-    pub write_ios: u64,
-    pub write_merges: u64,
-    pub write_sectors: u64,
-    pub write_ticks: u64,
-    pub in_flight: u64,
-    pub io_ticks: u64,
-    pub time_in_queue: u64
+    pub read_ios: usize,
+    pub read_merges: usize,
+    pub read_sectors: usize,
+    pub read_ticks: usize,
+    pub write_ios: usize,
+    pub write_merges: usize,
+    pub write_sectors: usize,
+    pub write_ticks: usize,
+    pub in_flight: usize,
+    pub io_ticks: usize,
+    pub time_in_queue: usize,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/data.rs
+++ b/src/data.rs
@@ -193,8 +193,6 @@ pub struct Network {
     pub addrs: Vec<NetworkAddrs>,
 }
 
-pub type Disk = String;
-
 #[derive(Debug, Clone)]
 pub struct BlockDeviceStats {
     pub name: String,

--- a/src/data.rs
+++ b/src/data.rs
@@ -173,6 +173,22 @@ pub struct Filesystem {
     pub fs_mounted_on: String,
 }
 
+#[derive(Debug, Clone)]
+pub struct BlockDeviceStats {
+    pub name: String,
+    pub read_ios: u64,
+    pub read_merges: u64,
+    pub read_sectors: u64,
+    pub read_ticks: u64,
+    pub write_ios: u64,
+    pub write_merges: u64,
+    pub write_sectors: u64,
+    pub write_ticks: u64,
+    pub in_flight: u64,
+    pub io_ticks: u64,
+    pub time_in_queue: u64
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum IpAddr {
     Empty,
@@ -191,20 +207,4 @@ pub struct NetworkAddrs {
 pub struct Network {
     pub name: String,
     pub addrs: Vec<NetworkAddrs>,
-}
-
-#[derive(Debug, Clone)]
-pub struct BlockDeviceStats {
-    pub name: String,
-    pub read_ios: u64,
-    pub read_merges: u64,
-    pub read_sectors: u64,
-    pub read_ticks: u64,
-    pub write_ios: u64,
-    pub write_merges: u64,
-    pub write_sectors: u64,
-    pub write_ticks: u64,
-    pub in_flight: u64,
-    pub io_ticks: u64,
-    pub time_in_queue: u64
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -197,15 +197,15 @@ pub type Disk = String;
 
 #[derive(Debug, Clone)]
 pub struct BlockDeviceStats {
-    read_ios: u64,
-    read_merges: u64,
-    read_sectors: u64,
-    read_ticks: u64,
-    write_ios: u64,
-    write_merges: u64,
-    write_sectors: u64,
-    write_ticks: u64,
-    in_flight: u64,
-    io_ticks: u64,
-    time_in_queue: u64
+    pub read_ios: u64,
+    pub read_merges: u64,
+    pub read_sectors: u64,
+    pub read_ticks: u64,
+    pub write_ios: u64,
+    pub write_merges: u64,
+    pub write_sectors: u64,
+    pub write_ticks: u64,
+    pub in_flight: u64,
+    pub io_ticks: u64,
+    pub time_in_queue: u64
 }

--- a/src/platform/common.rs
+++ b/src/platform/common.rs
@@ -57,6 +57,10 @@ pub trait Platform {
     /// Returns a vector of filesystem mount information objects.
     fn mounts(&self) -> io::Result<Vec<Filesystem>>;
 
+    fn block_devices(&self) -> io::Result<Vec<Disk>>;
+
+    fn block_device_statistics(&self, device: &str) -> io::Result<BlockDeviceStats>;
+
     /// Returns a filesystem mount information object for the filesystem at a given path.
     fn mount_at<P: AsRef<path::Path>>(&self, path: P) -> io::Result<Filesystem>;
 

--- a/src/platform/common.rs
+++ b/src/platform/common.rs
@@ -57,11 +57,11 @@ pub trait Platform {
     /// Returns a vector of filesystem mount information objects.
     fn mounts(&self) -> io::Result<Vec<Filesystem>>;
 
-    /// Returns a map of block device statistics objects
-    fn block_device_statistics(&self) -> io::Result<BTreeMap<String, BlockDeviceStats>>;
-
     /// Returns a filesystem mount information object for the filesystem at a given path.
     fn mount_at<P: AsRef<path::Path>>(&self, path: P) -> io::Result<Filesystem>;
+
+    /// Returns a map of block device statistics objects
+    fn block_device_statistics(&self) -> io::Result<BTreeMap<String, BlockDeviceStats>>;
 
     /// Returns a map of network intefrace information objects.
     ///

--- a/src/platform/common.rs
+++ b/src/platform/common.rs
@@ -57,9 +57,7 @@ pub trait Platform {
     /// Returns a vector of filesystem mount information objects.
     fn mounts(&self) -> io::Result<Vec<Filesystem>>;
 
-    fn block_devices(&self) -> io::Result<Vec<Disk>>;
-
-    fn block_device_statistics(&self, device: &str) -> io::Result<BlockDeviceStats>;
+    fn block_device_statistics(&self) -> io::Result<BTreeMap<String, BlockDeviceStats>>;
 
     /// Returns a filesystem mount information object for the filesystem at a given path.
     fn mount_at<P: AsRef<path::Path>>(&self, path: P) -> io::Result<Filesystem>;

--- a/src/platform/common.rs
+++ b/src/platform/common.rs
@@ -57,6 +57,7 @@ pub trait Platform {
     /// Returns a vector of filesystem mount information objects.
     fn mounts(&self) -> io::Result<Vec<Filesystem>>;
 
+    /// Returns a map of block device statistics objects
     fn block_device_statistics(&self) -> io::Result<BTreeMap<String, BlockDeviceStats>>;
 
     /// Returns a filesystem mount information object for the filesystem at a given path.

--- a/src/platform/freebsd.rs
+++ b/src/platform/freebsd.rs
@@ -145,11 +145,7 @@ impl Platform for PlatformImpl {
         unix::networks()
     }
 
-    fn block_devices(&self) -> io::Result<Vec<Disk>> {
-        Err(io::Error::new(io::ErrorKind::Other, "Not supported"))
-    }
-
-    fn block_device_statistics(&self, device: &str) -> io::Result<BlockDeviceStats> {
+    fn block_device_statistics(&self) -> io::Result<BTreeMap<String, BlockDeviceStats>> {
         Err(io::Error::new(io::ErrorKind::Other, "Not supported"))
     }
 

--- a/src/platform/freebsd.rs
+++ b/src/platform/freebsd.rs
@@ -145,6 +145,14 @@ impl Platform for PlatformImpl {
         unix::networks()
     }
 
+    fn block_devices(&self) -> io::Result<Vec<Disk>> {
+        Err(io::Error::new(io::ErrorKind::Other, "Not supported"))
+    }
+
+    fn block_device_statistics(&self, device: &str) -> io::Result<BlockDeviceStats> {
+        Err(io::Error::new(io::ErrorKind::Other, "Not supported"))
+    }
+
     fn cpu_temp(&self) -> io::Result<f32> {
         let mut temp: i32 = 0; sysctl!(CPU0TEMP, &mut temp, mem::size_of::<i32>());
         // The sysctl interface supports more units, but both amdtemp and coretemp always

--- a/src/platform/freebsd.rs
+++ b/src/platform/freebsd.rs
@@ -141,12 +141,12 @@ impl Platform for PlatformImpl {
         Ok(sfs.to_fs())
     }
 
-    fn networks(&self) -> io::Result<BTreeMap<String, Network>> {
-        unix::networks()
-    }
-
     fn block_device_statistics(&self) -> io::Result<BTreeMap<String, BlockDeviceStats>> {
         Err(io::Error::new(io::ErrorKind::Other, "Not supported"))
+    }
+
+    fn networks(&self) -> io::Result<BTreeMap<String, Network>> {
+        unix::networks()
     }
 
     fn cpu_temp(&self) -> io::Result<f32> {

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -360,11 +360,7 @@ impl Platform for PlatformImpl {
         unix::networks()
     }
 
-    fn block_devices(&self) -> io::Result<Vec<Disk>> {
-        Err(io::Error::new(io::ErrorKind::Other, "Not supported"))
-    }
-
-    fn block_device_statistics(&self, device: &str) -> io::Result<BlockDeviceStats> {
+    fn block_device_statistics(&self) -> io::Result<BTreeMap<String, BlockDeviceStats>> {
         Err(io::Error::new(io::ErrorKind::Other, "Not supported"))
     }
 

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -360,6 +360,14 @@ impl Platform for PlatformImpl {
         unix::networks()
     }
 
+    fn block_devices(&self) -> io::Result<Vec<Disk>> {
+        Err(io::Error::new(io::ErrorKind::Other, "Not supported"))
+    }
+
+    fn block_device_statistics(&self, device: &str) -> io::Result<BlockDeviceStats> {
+        Err(io::Error::new(io::ErrorKind::Other, "Not supported"))
+    }
+
     fn cpu_temp(&self) -> io::Result<f32> {
         read_file("/sys/class/thermal/thermal_zone0/temp")
             .and_then(|data| match data.parse::<f32>() {

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -411,6 +411,7 @@ impl Platform for PlatformImpl {
                     .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))
             })
         );
+
         for blkstats in stats {
             result.entry(blkstats.name.clone()).or_insert(blkstats);
         }

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -200,30 +200,24 @@ fn stat_mount(mount: ProcMountsData) -> io::Result<Filesystem> {
     }
 }
 
-/// Parse a single number
-named!(num_s<u64>, flat_map!(
-    map_res!(take_till!(is_space), str::from_utf8),
-    parse_to!(u64)
-));
-
 /// Parse a line of `/proc/diskstats`
 named!(
     proc_diskstats_line<BlockDeviceStats>,
     ws!(do_parse!(
-        major_number: num_s >>
-        minor_number: num_s >>
+        major_number: usize_s >>
+        minor_number: usize_s >>
         name: word_s >>
-        read_ios: num_s >>
-        read_merges: num_s >>
-        read_sectors: num_s >>
-        read_ticks: num_s >>
-        write_ios: num_s >>
-        write_merges: num_s >>
-        write_sectors: num_s >>
-        write_ticks: num_s >>
-        in_flight: num_s >>
-        io_ticks: num_s >>
-        time_in_queue: num_s >>
+        read_ios: usize_s >>
+        read_merges: usize_s >>
+        read_sectors: usize_s >>
+        read_ticks: usize_s >>
+        write_ios: usize_s >>
+        write_merges: usize_s >>
+        write_sectors: usize_s >>
+        write_ticks: usize_s >>
+        in_flight: usize_s >>
+        io_ticks: usize_s >>
+        time_in_queue: usize_s >>
         (BlockDeviceStats {
             name: name,
             read_ios: read_ios,

--- a/src/platform/openbsd.rs
+++ b/src/platform/openbsd.rs
@@ -118,12 +118,12 @@ impl Platform for PlatformImpl {
         Err(io::Error::new(io::ErrorKind::Other, "Not supported"))
     }
 
-    fn networks(&self) -> io::Result<BTreeMap<String, Network>> {
-        unix::networks()
-    }
-
     fn block_device_statistics(&self) -> io::Result<BTreeMap<String, BlockDeviceStats>> {
         Err(io::Error::new(io::ErrorKind::Other, "Not supported"))
+    }
+
+    fn networks(&self) -> io::Result<BTreeMap<String, Network>> {
+        unix::networks()
     }
 
     fn cpu_temp(&self) -> io::Result<f32> {

--- a/src/platform/openbsd.rs
+++ b/src/platform/openbsd.rs
@@ -122,6 +122,14 @@ impl Platform for PlatformImpl {
         unix::networks()
     }
 
+    fn block_devices(&self) -> io::Result<Vec<Disk>> {
+        Err(io::Error::new(io::ErrorKind::Other, "Not supported"))
+    }
+
+    fn block_device_statistics(&self, device: &str) -> io::Result<BlockDeviceStats> {
+        Err(io::Error::new(io::ErrorKind::Other, "Not supported"))
+    }
+
     fn cpu_temp(&self) -> io::Result<f32> {
         Err(io::Error::new(io::ErrorKind::Other, "Not supported"))
     }

--- a/src/platform/openbsd.rs
+++ b/src/platform/openbsd.rs
@@ -122,11 +122,7 @@ impl Platform for PlatformImpl {
         unix::networks()
     }
 
-    fn block_devices(&self) -> io::Result<Vec<Disk>> {
-        Err(io::Error::new(io::ErrorKind::Other, "Not supported"))
-    }
-
-    fn block_device_statistics(&self, device: &str) -> io::Result<BlockDeviceStats> {
+    fn block_device_statistics(&self) -> io::Result<BTreeMap<String, BlockDeviceStats>> {
         Err(io::Error::new(io::ErrorKind::Other, "Not supported"))
     }
 

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -85,11 +85,11 @@ impl Platform for PlatformImpl {
         Err(io::Error::new(io::ErrorKind::Other, "Not supported"))
     }
 
-    fn networks(&self) -> io::Result<BTreeMap<String, Network>> {
+    fn block_device_statistics(&self) -> io::Result<BTreeMap<String, BlockDeviceStats>> {
         Err(io::Error::new(io::ErrorKind::Other, "Not supported"))
     }
 
-    fn block_device_statistics(&self) -> io::Result<BTreeMap<String, BlockDeviceStats>> {
+    fn networks(&self) -> io::Result<BTreeMap<String, Network>> {
         Err(io::Error::new(io::ErrorKind::Other, "Not supported"))
     }
 

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -89,11 +89,7 @@ impl Platform for PlatformImpl {
         Err(io::Error::new(io::ErrorKind::Other, "Not supported"))
     }
 
-    fn block_devices(&self) -> io::Result<Vec<Disk>> {
-        Err(io::Error::new(io::ErrorKind::Other, "Not supported"))
-    }
-
-    fn block_device_statistics(&self, device: &str) -> io::Result<BlockDeviceStats> {
+    fn block_device_statistics(&self) -> io::Result<BTreeMap<String, BlockDeviceStats>> {
         Err(io::Error::new(io::ErrorKind::Other, "Not supported"))
     }
 

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -89,6 +89,14 @@ impl Platform for PlatformImpl {
         Err(io::Error::new(io::ErrorKind::Other, "Not supported"))
     }
 
+    fn block_devices(&self) -> io::Result<Vec<Disk>> {
+        Err(io::Error::new(io::ErrorKind::Other, "Not supported"))
+    }
+
+    fn block_device_statistics(&self, device: &str) -> io::Result<BlockDeviceStats> {
+        Err(io::Error::new(io::ErrorKind::Other, "Not supported"))
+    }
+
     fn cpu_temp(&self) -> io::Result<f32> {
         Err(io::Error::new(io::ErrorKind::Other, "Not supported"))
     }


### PR DESCRIPTION
Add IO statistics for block devices for linux

Tested live with example added to `example/info.rs`.