### PR TITLE
(linux) Expose swap stats on failed meminfo

### DIFF
--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -252,6 +252,14 @@ impl Platform for PlatformImpl {
                     "Buffers".to_owned(),
                     ByteSize::b(info.bufferram as usize * unit),
                 );
+                meminfo.insert(
+                    "SwapTotal".to_owned(),
+                    ByteSize::b(info.totalswap as usize * unit),
+                );
+                meminfo.insert(
+                    "SwapFree".to_owned(),
+                    ByteSize::b(info.freeswap as usize * unit),
+                );
                 Ok(meminfo)
             })
             .map(|meminfo| {


### PR DESCRIPTION
Swap statistics are useful. I've exposed them from the sysinfo call if reading from `/proc/meminfo` fails.

I tested this by forcing an error. Previous examples apply.