### PR TITLE
(Linux) Socket stats

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,5 +22,4 @@ nom = "3.2"
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-winapi = "0.2"
-kernel32-sys = "0.2"
+winapi = "0.3"

--- a/examples/info.rs
+++ b/examples/info.rs
@@ -92,4 +92,9 @@ fn main() {
         Ok(cpu_temp) => println!("\nCPU temp: {}", cpu_temp),
         Err(x) => println!("\nCPU temp: {}", x)
     }
+
+    match sys.socket_stats() {
+        Ok(stats) => println!("\nSystem socket statistics: {:?}", stats),
+        Err(x) => println!("\nError: {}", x.to_string())
+    }
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -218,3 +218,12 @@ pub struct NetworkStats {
     pub rx_errors: usize,
     pub tx_errors: usize,
 }
+
+#[derive(Debug, Clone)]
+pub struct SocketStats {
+    pub tcp_sockets_in_use: usize,
+    pub tcp_sockets_orphaned: usize,
+    pub udp_sockets_in_use: usize,
+    pub tcp6_sockets_in_use: usize,
+    pub udp6_sockets_in_use: usize,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,6 @@
 extern crate libc;
 #[cfg(windows)]
 extern crate winapi;
-#[cfg(windows)]
-extern crate kernel32;
 extern crate bytesize;
 extern crate time;
 extern crate chrono;

--- a/src/platform/common.rs
+++ b/src/platform/common.rs
@@ -77,4 +77,7 @@ pub trait Platform {
     ///
     /// Depending on the platform, this might be core 0, package, etc.
     fn cpu_temp(&self) -> io::Result<f32>;
+
+    /// Returns information about the number of sockets in use
+    fn socket_stats(&self) -> io::Result<SocketStats>;
 }

--- a/src/platform/freebsd.rs
+++ b/src/platform/freebsd.rs
@@ -159,6 +159,10 @@ impl Platform for PlatformImpl {
         // use IK (deciKelvin)
         Ok((temp as f32 - 2731.5) / 10.0)
     }
+
+    fn socket_stats(&self) -> io::Result<SocketStats> {
+        Err(io::Error::new(io::ErrorKind::Other, "Not supported"))
+    }
 }
 
 

--- a/src/platform/openbsd.rs
+++ b/src/platform/openbsd.rs
@@ -133,6 +133,10 @@ impl Platform for PlatformImpl {
     fn cpu_temp(&self) -> io::Result<f32> {
         Err(io::Error::new(io::ErrorKind::Other, "Not supported"))
     }
+
+    fn socket_stats(&self) -> io::Result<SocketStats> {
+        Err(io::Error::new(io::ErrorKind::Other, "Not supported"))
+    }
 }
 
 fn measure_cpu() -> io::Result<Vec<CpuTime>> {

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -100,6 +100,10 @@ impl Platform for PlatformImpl {
     fn cpu_temp(&self) -> io::Result<f32> {
         Err(io::Error::new(io::ErrorKind::Other, "Not supported"))
     }
+
+    fn socket_stats(&self) -> io::Result<SocketStats> {
+        Err(io::Error::new(io::ErrorKind::Other, "Not supported"))
+    }
 }
 
 fn power_status() -> winbase::SYSTEM_POWER_STATUS {


### PR DESCRIPTION
Hopefully this is the last one :)

Added basic socket statistics for the system (used tcp/udp/tcp6/udp6 sockets, and orphaned tcp sockets). Plausible for BSD also (I think).