### PR TITLE
[Linux] add trim on cpu_temp

### DIFF
--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -504,7 +504,7 @@ impl Platform for PlatformImpl {
 
     fn cpu_temp(&self) -> io::Result<f32> {
         read_file("/sys/class/thermal/thermal_zone0/temp")
-            .and_then(|data| match data.parse::<f32>() {
+            .and_then(|data| match data.trim().parse::<f32>() {
                 Ok(x) => Ok(x),
                 Err(_) => Err(io::Error::new(io::ErrorKind::Other, "Could not parse float")),
             })


### PR DESCRIPTION
hello, my device got error on cpu_temp()
-> Err(Custom { kind: Other, error: StringError("Could not parse float") })

while digging into it, i found read_file("/sys/class/thermal/thermal_zone0/temp") returns "44000 **\n** "
because it has whitespace, rust couldn't parse correctly and return error. 
to solve this, i added trim() on the code.


Here's some information about my system:

- Linux Mint 18.04 (kernel: 4.15.0-32-generic)
- rustc 1.28.0

it's a minor bug, but i hope it helps someone.

![image](https://user-images.githubusercontent.com/11001371/44537338-7b652200-a739-11e8-8a14-8f4396ecc4f8.png)