### PR TITLE
Read CPU temperature from hwmon interface.

### DIFF
--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -511,6 +511,7 @@ impl Platform for PlatformImpl {
 
     fn cpu_temp(&self) -> io::Result<f32> {
         read_file("/sys/class/thermal/thermal_zone0/temp")
+            .or(read_file("/sys/class/hwmon/hwmon0/temp1_input"))
             .and_then(|data| match data.trim().parse::<f32>() {
                 Ok(x) => Ok(x),
                 Err(_) => Err(io::Error::new(io::ErrorKind::Other, "Could not parse float")),


### PR DESCRIPTION
Adds the alternative of reading the CPU temperature from hwmon when thermal_zone is unavailable.

Apparently some setups may not have any `thermal_zone` under `/sys/class/thermal/`, but may have the hwmon interface (more on that [here](https://www.kernel.org/doc/Documentation/thermal/sysfs-api.txt)).

Let me know if you think this change makes sense.

Cheers