### PR TITLE
Get boot_time from /proc/stat on Linux

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -6,7 +6,7 @@ use std::io;
 pub use std::time::Duration;
 pub use std::net::{Ipv4Addr, Ipv6Addr};
 pub use std::collections::BTreeMap;
-pub use chrono::{DateTime, Utc, NaiveDateTime};
+pub use chrono::{DateTime, Utc, NaiveDateTime, TimeZone};
 pub use bytesize::ByteSize;
 use std::ops::Sub;
 


### PR DESCRIPTION
Should be less jittery than calculating from uptime.