### PR TITLE
Implement mount_at for all platforms

### DIFF
--- a/src/platform/common.rs
+++ b/src/platform/common.rs
@@ -58,7 +58,15 @@ pub trait Platform {
     fn mounts(&self) -> io::Result<Vec<Filesystem>>;
 
     /// Returns a filesystem mount information object for the filesystem at a given path.
-    fn mount_at<P: AsRef<path::Path>>(&self, path: P) -> io::Result<Filesystem>;
+    fn mount_at<P: AsRef<path::Path>>(&self, path: P) -> io::Result<Filesystem> {
+        self.mounts()
+            .and_then(|mounts| {
+                mounts
+                    .into_iter()
+                    .find(|mount| path::Path::new(&mount.fs_mounted_on) == path.as_ref())
+                    .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "No such mount"))
+        })
+    }
 
     /// Returns a map of block device statistics objects
     fn block_device_statistics(&self) -> io::Result<BTreeMap<String, BlockDeviceStats>>;

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -83,16 +83,6 @@ impl Platform for PlatformImpl {
         Ok(mounts.iter().map(statfs_to_fs).collect::<Vec<_>>())
     }
 
-    fn mount_at<P: AsRef<path::Path>>(&self, path: P) -> io::Result<Filesystem> {
-        self.mounts()
-            .and_then(|mounts| {
-                mounts
-                    .into_iter()
-                    .find(|mount| path::Path::new(&mount.fs_mounted_on) == path.as_ref())
-                    .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "No such mount"))
-        })
-    }
-
     fn block_device_statistics(&self) -> io::Result<BTreeMap<String, BlockDeviceStats>> {
         Err(io::Error::new(io::ErrorKind::Other, "Not supported"))
     }

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -83,8 +83,14 @@ impl Platform for PlatformImpl {
         Ok(mounts.iter().map(statfs_to_fs).collect::<Vec<_>>())
     }
 
-    fn mount_at<P: AsRef<path::Path>>(&self, _: P) -> io::Result<Filesystem> {
-        Err(io::Error::new(io::ErrorKind::Other, "Not supported"))
+    fn mount_at<P: AsRef<path::Path>>(&self, path: P) -> io::Result<Filesystem> {
+        self.mounts()
+            .and_then(|mounts| {
+                mounts
+                    .into_iter()
+                    .find(|mount| path::Path::new(&mount.fs_mounted_on) == path.as_ref())
+                    .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "No such mount"))
+        })
     }
 
     fn block_device_statistics(&self) -> io::Result<BTreeMap<String, BlockDeviceStats>> {


### PR DESCRIPTION
Simply uses `mounts` and looks for the given path as a mount point in the result.