### PR TITLE
Made DelayedMeasurement Send, fixed network test on Linux

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -14,12 +14,12 @@ use std::ops::Sub;
 ///
 /// Time should pass between getting the object and calling .done() on it.
 pub struct DelayedMeasurement<T> {
-    res: Box<Fn() -> io::Result<T>>,
+    res: Box<Fn() -> io::Result<T> + Send>,
 }
 
 impl<T> DelayedMeasurement<T> {
     #[inline(always)]
-    pub fn new(f: Box<Fn() -> io::Result<T>>) -> DelayedMeasurement<T> {
+    pub fn new(f: Box<Fn() -> io::Result<T> + Send>) -> DelayedMeasurement<T> {
         DelayedMeasurement { res: f }
     }
 

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -100,7 +100,16 @@ mod tests {
     #[test]
     fn test_networks() {
         let networks = PlatformImpl::new().networks().unwrap();
-        assert!(networks.values().find(|n| n.name == "lo0").unwrap().addrs.len() > 0);
+        assert!(networks.values().filter(|n| n.name == "lo" || n.name == "lo0").next().unwrap().addrs.len() > 0);
+    }
+
+    #[test]
+    fn test_cpu_measurement_is_send() {
+        use crate::{DelayedMeasurement, CPULoad};
+        fn take_delayed(dm: DelayedMeasurement<Vec<CPULoad>>) {
+            use std::thread;
+            thread::spawn(move || dm);
+        }
     }
 
 }


### PR DESCRIPTION
Having `DelayedMeasurement` be `Send` is extremely useful when using this crate with a futures-driven codebase.

Also, I fixed a test that failed on my setup due to an incorrect network interface name.