### PR TITLE
Fix for FreeBSD issues

### DIFF
--- a/src/platform/freebsd.rs
+++ b/src/platform/freebsd.rs
@@ -210,8 +210,8 @@ struct statfs {
     f_fsid: fsid_t,
     f_charspare: [c_schar; 80],
     f_fstypename: [c_schar; 16],
-    f_mntfromname: [c_schar; 88],
-    f_mntonname: [c_schar; 88],
+    f_mntfromname: [c_schar; 1024],
+    f_mntonname: [c_schar; 1024],
 }
 
 impl statfs {

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -38,6 +38,7 @@ mod tests {
     use super::*;
     use std::thread;
     use std::time::Duration;
+    use std::path::PathBuf;
 
     #[test]
     fn test_cpu_load() {
@@ -93,7 +94,8 @@ mod tests {
 
     #[test]
     fn test_mount_at() {
-        let mount = PlatformImpl::new().mount_at("/").unwrap();
+        let path = PathBuf::from("/");
+        let mount = PlatformImpl::new().mount_at(path).unwrap();
         assert!(mount.fs_mounted_on == "/");
     }
 


### PR DESCRIPTION
Fix for #60
Swapped out some of the FreeBSD statfs struct's field sizes  with what they had in the [man page](https://www.freebsd.org/cgi/man.cgi?query=statfs&sektion=2). Test's are passing for me on 2 machines both running FreeBSD 12 w/ ZFS.