### PR TITLE
 NetworkStats should use u64 so 32-bit architectures can report stats of greater than 4GiB

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -286,12 +286,12 @@ pub struct Network {
 
 #[derive(Debug, Clone)]
 pub struct NetworkStats {
-    pub rx_bytes: usize,
-    pub tx_bytes: usize,
-    pub rx_packets: usize,
-    pub tx_packets: usize,
-    pub rx_errors: usize,
-    pub tx_errors: usize,
+    pub rx_bytes: ByteSize,
+    pub tx_bytes: ByteSize,
+    pub rx_packets: u64,
+    pub tx_packets: u64,
+    pub rx_errors: u64,
+    pub tx_errors: u64,
 }
 
 #[derive(Debug, Clone)]

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -507,20 +507,20 @@ impl Platform for PlatformImpl {
         let path_root: String = ("/sys/class/net/".to_string() + interface) + "/statistics/";
         let stats_file = |file: &str| (&path_root).to_string() + file;
 
-        let rx_bytes: usize = try!(value_from_file::<usize>(&stats_file("rx_bytes")));
-        let tx_bytes: usize = try!(value_from_file::<usize>(&stats_file("tx_bytes")));
-        let rx_packets: usize = try!(value_from_file::<usize>(&stats_file("rx_packets")));
-        let tx_packets: usize = try!(value_from_file::<usize>(&stats_file("tx_packets")));
-        let rx_errors: usize = try!(value_from_file::<usize>(&stats_file("rx_errors")));
-        let tx_errors: usize = try!(value_from_file::<usize>(&stats_file("tx_errors")));
+        let rx_bytes: u64 = try!(value_from_file::<u64>(&stats_file("rx_bytes")));
+        let tx_bytes: u64 = try!(value_from_file::<u64>(&stats_file("tx_bytes")));
+        let rx_packets: u64 = try!(value_from_file::<u64>(&stats_file("rx_packets")));
+        let tx_packets: u64 = try!(value_from_file::<u64>(&stats_file("tx_packets")));
+        let rx_errors: u64 = try!(value_from_file::<u64>(&stats_file("rx_errors")));
+        let tx_errors: u64 = try!(value_from_file::<u64>(&stats_file("tx_errors")));
 
         Ok(NetworkStats {
-            rx_bytes,
-            tx_bytes,
-            rx_packets,
-            tx_packets,
-            rx_errors,
-            tx_errors,
+            rx_bytes: ByteSize::b(rx_bytes),
+            tx_bytes: ByteSize::b(tx_bytes),
+            rx_packets: rx_packets,
+            tx_packets: tx_packets,
+            rx_errors: rx_errors,
+            tx_errors: tx_errors,
         })
     }
 

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -106,7 +106,7 @@ impl Platform for PlatformImpl {
 
 fn statfs_to_fs(x: &statfs) -> Filesystem {
     Filesystem {
-        files: (x.f_files as usize.saturating_sub(x.f_ffree as usize),
+        files: (x.f_files as usize).saturating_sub(x.f_ffree as usize),
         files_total: x.f_files as usize,
         files_avail: x.f_ffree as usize,
         free: ByteSize::b(x.f_bfree * x.f_bsize as u64),


### PR DESCRIPTION
I'm using this library on an armv7 processor which is 32-bit. I hit an issue that once the data sent/received had surpassed 4GiB, the `network_stats` function began to error out as the number of bytes could no longer fit in a `usize`.

This PR changes the NetworkStats struct so that `rx_bytes` and `tx_bytes` are now `ByteSize`, and the other fields are now `u64`.