### PR TITLE
fixed warnings

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -19,12 +19,12 @@ pub fn saturating_sub_bytes(l: ByteSize, r: ByteSize) -> ByteSize {
 ///
 /// Time should pass between getting the object and calling .done() on it.
 pub struct DelayedMeasurement<T> {
-    res: Box<Fn() -> io::Result<T> + Send>,
+    res: Box<dyn Fn() -> io::Result<T> + Send>,
 }
 
 impl<T> DelayedMeasurement<T> {
     #[inline(always)]
-    pub fn new(f: Box<Fn() -> io::Result<T> + Send>) -> DelayedMeasurement<T> {
+    pub fn new(f: Box<dyn Fn() -> io::Result<T> + Send>) -> DelayedMeasurement<T> {
         DelayedMeasurement { res: f }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ extern crate libc;
 extern crate time;
 extern crate chrono;
 extern crate bytesize;
+#[macro_use]
 extern crate lazy_static;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@ extern crate libc;
 extern crate time;
 extern crate chrono;
 extern crate bytesize;
-#[macro_use]
 extern crate lazy_static;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 #[macro_use]

--- a/src/platform/common.rs
+++ b/src/platform/common.rs
@@ -17,7 +17,7 @@ pub trait Platform {
     /// You need to wait some time (about a second is good) before unwrapping the
     /// `DelayedMeasurement` with `.done()`.
     fn cpu_load_aggregate(&self) -> io::Result<DelayedMeasurement<CPULoad>> {
-        let measurement = try!(self.cpu_load());
+        let measurement = self.cpu_load()?;
         Ok(DelayedMeasurement::new(
                 Box::new(move || measurement.done().map(|ls| {
                     let mut it = ls.iter();
@@ -36,15 +36,15 @@ pub trait Platform {
     fn uptime(&self) -> io::Result<Duration> {
         self.boot_time().and_then(|bt| {
             time::Duration::to_std(&Utc::now().signed_duration_since(bt))
-                .map_err(|e| io::Error::new(io::ErrorKind::Other, "Could not process time"))
+                .map_err(|_| io::Error::new(io::ErrorKind::Other, "Could not process time"))
         })
     }
 
     /// Returns the system boot time.
     fn boot_time(&self) -> io::Result<DateTime<Utc>> {
         self.uptime().and_then(|ut| {
-            Ok(Utc::now() - try!(time::Duration::from_std(ut)
-                .map_err(|e| io::Error::new(io::ErrorKind::Other, "Could not process time"))))
+            Ok(Utc::now() - time::Duration::from_std(ut)
+                .map_err(|_| io::Error::new(io::ErrorKind::Other, "Could not process time"))?)
         })
     }
 

--- a/src/platform/unix.rs
+++ b/src/platform/unix.rs
@@ -24,7 +24,7 @@ pub fn networks() -> io::Result<BTreeMap<String, Network>> {
     while ifap != ptr::null_mut() {
         let ifa = unsafe { (*ifap) };
         let name = unsafe { ffi::CStr::from_ptr(ifa.ifa_name).to_string_lossy().into_owned() };
-        let mut entry = result.entry(name.clone()).or_insert(Network {
+        let entry = result.entry(name.clone()).or_insert(Network {
             name: name,
             addrs: Vec::new(),
         });


### PR DESCRIPTION
fixed compiler warnings:  
- replaced deprecated 'try!(...)' macro with '?' operator
- using new 'dyn Trait' syntax
- renamed unused closure input variables to '_' (maybe change to '_e' ?)
- changed docstrings to regular comments where not supported
- <s>removed unused '#[macro_use]' import</s>
- replaced deprecated 'trim_right_matches' with 'trim_end_matches'
- removed unused mutability