### PR TITLE
Added `cpu_load` support on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,4 @@ nom = "3.2"
 
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3"
-features = ["fileapi", "sysinfoapi", "minwindef", "winbase", "winerror", "ws2def", "ws2ipdef"]
+features = ["fileapi", "sysinfoapi", "minwindef", "winbase", "winerror", "ws2def", "ws2ipdef", "pdh"]


### PR DESCRIPTION
Added `cpu_load` support on Windows using Pdh. The tests fail randomly as the returned values dont always add to a number close to 1.00. `nice` is also unpopulated, and left as 0.

Fixes #65 