### PR TITLE
Upgrade to nom 6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ bytesize = "1.0"
 libc = "0.2"
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
-nom = "3.2"
+nom = "6.0"
 
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@ extern crate bytesize;
 #[cfg_attr(any(target_os = "freebsd", target_os = "openbsd", target_os = "macos"), macro_use)]
 extern crate lazy_static;
 #[cfg(any(target_os = "linux", target_os = "android"))]
-#[macro_use]
 extern crate nom;
 
 pub mod platform;


### PR DESCRIPTION
This removes all usages of deprecated/removed parsers, and migrates to the functional paradigm that is recommended in nom 5+.

Closes #48