### PR TITLE
Add unit tests and associated bugfixes for remaining linux parsers 

### DIFF
--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -6,7 +6,7 @@ use libc::{c_char, c_long, c_schar, c_uint, c_ulong, c_ushort};
 use nom::bytes::complete::{tag, take_till, take_until};
 use nom::character::complete::{digit1, multispace0, not_line_ending, space1};
 use nom::character::is_space;
-use nom::combinator::{complete, map, map_res, opt};
+use nom::combinator::{complete, map, map_res, opt, verify};
 use nom::error::ParseError;
 use nom::multi::{fold_many0, many0, many1};
 use nom::sequence::{delimited, preceded, tuple};
@@ -113,6 +113,43 @@ fn proc_stat_cpu_times(input: &str) -> IResult<&str, Vec<CpuTime>> {
     )(input)
 }
 
+#[test]
+fn test_proc_stat_cpu_times() {
+    let input = "cpu  5972658 30964 2383250 392840200 70075 0 43945 0 0 0
+cpu0 444919 3155 198700 24405593 4622 0 36738 0 0 0
+cpu1 296558 428 76249 24715635 1426 0 1280 0 0 0
+cpu2 402963 949 231689 24417433 6386 0 1780 0 0 0
+cpu3 301571 2452 88088 24698799 1906 0 177 0 0 0
+cpu4 427192 2896 200043 24427598 4640 0 519 0 0 0
+cpu5 301433 515 86228 24695368 3925 0 107 0 0 0
+cpu6 432794 2884 202838 24426726 4213 0 380 0 0 0
+cpu7 304364 337 89802 24709831 2965 0 78 0 0 0
+cpu8 475829 3608 211253 24379789 5645 0 438 0 0 0
+cpu9 306784 880 86744 24704036 4669 0 81 0 0 0
+cpu10 444170 3768 212504 24415053 5346 0 331 0 0 0
+cpu11 300957 519 87052 24712048 4294 0 77 0 0 0
+cpu12 445953 3608 209153 24415924 5458 0 288 0 0 0
+cpu13 318262 752 89195 24681010 4133 0 1254 0 0 0
+cpu14 451390 3802 216997 24404205 4852 0 283 0 0 0
+cpu15 317509 401 96705 24631145 5588 0 124 0 0 0
+intr 313606509 40 27 0 0 0 0 0 58 1 94578 0 2120 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 31 170440 151744 109054 197097 174402 169253 171292 0 0 0 1251812 0 0 0 0 0 0 0 0 6302 0 0 0 0 0 0 0 58 0 0 0 0 0 916279 10132 140390 8096 69021 79664 26669 79961 34865 33195 102807 124189 76108 69587 7073 3 9710 116522 10436256 0 2079496 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+ctxt 535905166
+btime 1605203377
+processes 1360293
+procs_running 1
+procs_blocked 0
+softirq 81473629 1251347 8827732 10 325789 37 0 177903 43807896 2777 27080138
+";
+    let result = proc_stat_cpu_times(input).unwrap().1;
+    assert_eq!(result.len(), 16);
+    assert_eq!(result[0].user, 444919);
+    assert_eq!(result[0].nice, 3155);
+    assert_eq!(result[0].system, 198700);
+    assert_eq!(result[0].idle, 24405593);
+    assert_eq!(result[0].other, 4622);
+    assert_eq!(result[0].interrupt, 0);
+}
+
 /// Get the current per-CPU `CpuTime` statistics
 fn cpu_time() -> io::Result<Vec<CpuTime>> {
     read_file("/proc/stat").and_then(|data| {
@@ -138,11 +175,14 @@ fn proc_meminfo_line_opt(input: &str) -> IResult<&str, Option<(&str, ByteSize)>>
 // Parse `/proc/meminfo` into a hashmap
 fn proc_meminfo(input: &str) -> IResult<&str, BTreeMap<String, ByteSize>> {
     fold_many0(
-        ws(map_res(not_line_ending, |input| {
-            proc_meminfo_line_opt(input)
-                .map(|(_, res)| res)
-                .map_err(|_| ())
-        })),
+        map_res(
+            verify(ws(not_line_ending), |item: &str| !item.is_empty()),
+            |input| {
+                proc_meminfo_line_opt(input)
+                    .map(|(_, res)| res)
+                    .map_err(|_| ())
+            },
+        ),
         BTreeMap::new(),
         |mut map: BTreeMap<String, ByteSize>, opt| {
             if let Some((key, val)) = opt {
@@ -151,6 +191,72 @@ fn proc_meminfo(input: &str) -> IResult<&str, BTreeMap<String, ByteSize>> {
             map
         },
     )(input)
+}
+
+#[test]
+fn test_proc_meminfo() {
+    let input = "MemTotal:       32345596 kB
+MemFree:        13160208 kB
+MemAvailable:   27792164 kB
+Buffers:            4724 kB
+Cached:         14776312 kB
+SwapCached:            0 kB
+Active:          8530160 kB
+Inactive:        9572028 kB
+Active(anon):      18960 kB
+Inactive(anon):  3415400 kB
+Active(file):    8511200 kB
+Inactive(file):  6156628 kB
+Unevictable:           0 kB
+Mlocked:               0 kB
+SwapTotal:       6143996 kB
+SwapFree:        6143996 kB
+Dirty:             66124 kB
+Writeback:             0 kB
+AnonPages:       3313376 kB
+Mapped:           931060 kB
+Shmem:            134716 kB
+KReclaimable:     427080 kB
+Slab:             648316 kB
+SReclaimable:     427080 kB
+SUnreclaim:       221236 kB
+KernelStack:       18752 kB
+PageTables:        30576 kB
+NFS_Unstable:          0 kB
+Bounce:                0 kB
+WritebackTmp:          0 kB
+CommitLimit:    22316792 kB
+Committed_AS:    7944504 kB
+VmallocTotal:   34359738367 kB
+VmallocUsed:       78600 kB
+VmallocChunk:          0 kB
+Percpu:            10496 kB
+HardwareCorrupted:     0 kB
+AnonHugePages:         0 kB
+ShmemHugePages:        0 kB
+ShmemPmdMapped:        0 kB
+FileHugePages:         0 kB
+FilePmdMapped:         0 kB
+HugePages_Total:       0
+HugePages_Free:        0
+HugePages_Rsvd:        0
+HugePages_Surp:        0
+Hugepagesize:       2048 kB
+Hugetlb:               0 kB
+DirectMap4k:     1696884 kB
+DirectMap2M:    17616896 kB
+DirectMap1G:    13631488 kB
+";
+    let result = proc_meminfo(input).unwrap().1;
+    assert_eq!(result.len(), 47);
+    assert_eq!(
+        result.get(&"Buffers".to_string()),
+        Some(&ByteSize::kib(4724))
+    );
+    assert_eq!(
+        result.get(&"KReclaimable".to_string()),
+        Some(&ByteSize::kib(427080))
+    );
 }
 
 /// Get memory statistics
@@ -386,6 +492,20 @@ fn proc_diskstats(input: &str) -> IResult<&str, Vec<BlockDeviceStats>> {
             .map(|(_, res)| res)
             .map_err(|_| ())
     })))(input)
+}
+
+#[test]
+fn test_proc_diskstats() {
+    let input = " 259       0 nvme0n1 142537 3139 15957288 470540 1235382 57191 140728002 5369037 0 1801270 5898257 0 0 0 0 102387 58679
+ 259       1 nvme0n1p1 767 2505 20416 1330 2 0 2 38 0 200 1369 0 0 0 0 0 0
+ 259       2 nvme0n1p2 65 0 4680 37 0 0 0 0 0 44 37 0 0 0 0 0 0
+ 259       3 nvme0n1p3 141532 634 15927512 469040 1132993 57191 140728000 5308878 0 1801104 5777919 0 0 0 0 0 0
+";
+    let result = proc_diskstats(input).unwrap().1;
+    assert_eq!(result.len(), 4);
+    assert_eq!(&result[3].name, "nvme0n1p3");
+    assert_eq!(result[3].read_ios, 141532);
+    assert_eq!(result[3].write_ios, 1132993);
 }
 
 pub struct PlatformImpl;


### PR DESCRIPTION
The existing tests weren't catching some of the potential parsing errors. These tests with hardcoded input should be more reliable.