### PR TITLE
Added Serialize and Deserialize traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,11 @@ repository = "https://github.com/myfreeweb/systemstat"
 
 [dependencies]
 time = "0.1"
-chrono = {version = "0.4.19", features = ["serde"] }
+chrono = "0.4"
 lazy_static = "1.0"
-bytesize = { version = "1.0.1", features = ["serde"] }
+bytesize = "1.0"
 libc = "0.2"
-serde = {version = "1.0.126", features = ["derive"] }
-
+serde-feature-hack = { version = "0.2.0", optional = true }
 
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
@@ -34,3 +33,6 @@ targets = [
 	"x86_64-apple-darwin",
 	"x86_64-pc-windows-msvc"
 ]
+
+[features]
+serde = ["serde-feature-hack", "bytesize/serde", "chrono/serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,13 @@ repository = "https://github.com/myfreeweb/systemstat"
 
 [dependencies]
 time = "0.1"
-chrono = "0.4"
+chrono = {version = "0.4.19", features = ["serde"] }
 lazy_static = "1.0"
-bytesize = "1.0"
+bytesize = { version = "1.0.1", features = ["serde"] }
 libc = "0.2"
+serde = {version = "1.0.126", features = ["derive"] }
+
+
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 nom = "6.0"

--- a/src/data.rs
+++ b/src/data.rs
@@ -8,6 +8,7 @@ pub use std::net::{Ipv4Addr, Ipv6Addr};
 pub use std::collections::BTreeMap;
 pub use chrono::{DateTime, Utc, NaiveDateTime, TimeZone};
 pub use bytesize::ByteSize;
+pub use serde::{Serialize, Deserialize};
 use std::ops::Sub;
 
 #[inline(always)]
@@ -39,7 +40,7 @@ impl<T> DelayedMeasurement<T> {
 pub struct PlatformCpuLoad {}
 
 #[cfg(target_os = "linux")]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PlatformCpuLoad {
     pub iowait: f32
 }
@@ -88,7 +89,7 @@ impl PlatformCpuLoad {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CPULoad {
     pub user: f32,
     pub nice: f32,
@@ -112,7 +113,7 @@ impl CPULoad {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct CpuTime {
     pub user: usize,
     pub nice: usize,
@@ -163,7 +164,7 @@ impl CpuTime {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LoadAverage {
     pub one: f32,
     pub five: f32,
@@ -171,7 +172,7 @@ pub struct LoadAverage {
 }
 
 #[cfg(target_os = "windows")]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PlatformMemory {
     pub load: u32,
     pub total_phys: ByteSize,
@@ -184,7 +185,7 @@ pub struct PlatformMemory {
 }
 
 #[cfg(target_os = "freebsd")]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PlatformMemory {
     pub active: ByteSize,
     pub inactive: ByteSize,
@@ -195,7 +196,7 @@ pub struct PlatformMemory {
 }
 
 #[cfg(target_os = "openbsd")]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PlatformMemory {
     pub active: ByteSize,
     pub inactive: ByteSize,
@@ -206,7 +207,7 @@ pub struct PlatformMemory {
 }
 
 #[cfg(target_os = "macos")]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PlatformMemory {
     pub active: ByteSize,
     pub inactive: ByteSize,
@@ -216,25 +217,25 @@ pub struct PlatformMemory {
 }
 
 #[cfg(any(target_os = "linux", target_os="android"))]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PlatformMemory {
     pub meminfo: BTreeMap<String, ByteSize>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Memory {
     pub total: ByteSize,
     pub free: ByteSize,
     pub platform_memory: PlatformMemory,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BatteryLife {
     pub remaining_capacity: f32,
     pub remaining_time: Duration,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Filesystem {
     pub files: usize,
     pub files_total: usize,
@@ -248,7 +249,7 @@ pub struct Filesystem {
     pub fs_mounted_on: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BlockDeviceStats {
     pub name: String,
     pub read_ios: usize,
@@ -264,7 +265,7 @@ pub struct BlockDeviceStats {
     pub time_in_queue: usize,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum IpAddr {
     Empty,
     Unsupported,
@@ -272,19 +273,19 @@ pub enum IpAddr {
     V6(Ipv6Addr),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NetworkAddrs {
     pub addr: IpAddr,
     pub netmask: IpAddr,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Network {
     pub name: String,
     pub addrs: Vec<NetworkAddrs>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NetworkStats {
     pub rx_bytes: ByteSize,
     pub tx_bytes: ByteSize,
@@ -294,7 +295,7 @@ pub struct NetworkStats {
     pub tx_errors: u64,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SocketStats {
     pub tcp_sockets_in_use: usize,
     pub tcp_sockets_orphaned: usize,

--- a/src/data.rs
+++ b/src/data.rs
@@ -8,8 +8,10 @@ pub use std::net::{Ipv4Addr, Ipv6Addr};
 pub use std::collections::BTreeMap;
 pub use chrono::{DateTime, Utc, NaiveDateTime, TimeZone};
 pub use bytesize::ByteSize;
-pub use serde::{Serialize, Deserialize};
 use std::ops::Sub;
+
+#[cfg(feature = "serde")]
+pub use serde::{Serialize, Deserialize};
 
 #[inline(always)]
 pub fn saturating_sub_bytes(l: ByteSize, r: ByteSize) -> ByteSize {
@@ -36,11 +38,13 @@ impl<T> DelayedMeasurement<T> {
 }
 
 #[cfg(not(target_os = "linux"))]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
 pub struct PlatformCpuLoad {}
 
 #[cfg(target_os = "linux")]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
 pub struct PlatformCpuLoad {
     pub iowait: f32
 }
@@ -89,7 +93,8 @@ impl PlatformCpuLoad {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
 pub struct CPULoad {
     pub user: f32,
     pub nice: f32,
@@ -113,7 +118,8 @@ impl CPULoad {
     }
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, Copy)]
 pub struct CpuTime {
     pub user: usize,
     pub nice: usize,
@@ -164,7 +170,8 @@ impl CpuTime {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
 pub struct LoadAverage {
     pub one: f32,
     pub five: f32,
@@ -172,7 +179,8 @@ pub struct LoadAverage {
 }
 
 #[cfg(target_os = "windows")]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
 pub struct PlatformMemory {
     pub load: u32,
     pub total_phys: ByteSize,
@@ -185,7 +193,8 @@ pub struct PlatformMemory {
 }
 
 #[cfg(target_os = "freebsd")]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
 pub struct PlatformMemory {
     pub active: ByteSize,
     pub inactive: ByteSize,
@@ -196,7 +205,8 @@ pub struct PlatformMemory {
 }
 
 #[cfg(target_os = "openbsd")]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
 pub struct PlatformMemory {
     pub active: ByteSize,
     pub inactive: ByteSize,
@@ -207,7 +217,8 @@ pub struct PlatformMemory {
 }
 
 #[cfg(target_os = "macos")]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
 pub struct PlatformMemory {
     pub active: ByteSize,
     pub inactive: ByteSize,
@@ -217,25 +228,29 @@ pub struct PlatformMemory {
 }
 
 #[cfg(any(target_os = "linux", target_os="android"))]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
 pub struct PlatformMemory {
     pub meminfo: BTreeMap<String, ByteSize>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
 pub struct Memory {
     pub total: ByteSize,
     pub free: ByteSize,
     pub platform_memory: PlatformMemory,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
 pub struct BatteryLife {
     pub remaining_capacity: f32,
     pub remaining_time: Duration,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
 pub struct Filesystem {
     pub files: usize,
     pub files_total: usize,
@@ -249,7 +264,8 @@ pub struct Filesystem {
     pub fs_mounted_on: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
 pub struct BlockDeviceStats {
     pub name: String,
     pub read_ios: usize,
@@ -265,7 +281,8 @@ pub struct BlockDeviceStats {
     pub time_in_queue: usize,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq)]
 pub enum IpAddr {
     Empty,
     Unsupported,
@@ -273,19 +290,22 @@ pub enum IpAddr {
     V6(Ipv6Addr),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
 pub struct NetworkAddrs {
     pub addr: IpAddr,
     pub netmask: IpAddr,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
 pub struct Network {
     pub name: String,
     pub addrs: Vec<NetworkAddrs>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
 pub struct NetworkStats {
     pub rx_bytes: ByteSize,
     pub tx_bytes: ByteSize,
@@ -295,7 +315,8 @@ pub struct NetworkStats {
     pub tx_errors: u64,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
 pub struct SocketStats {
     pub tcp_sockets_in_use: usize,
     pub tcp_sockets_orphaned: usize,

--- a/src/data.rs
+++ b/src/data.rs
@@ -36,7 +36,7 @@ impl<T> DelayedMeasurement<T> {
 }
 
 #[cfg(not(target_os = "linux"))]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PlatformCpuLoad {}
 
 #[cfg(target_os = "linux")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ extern crate libc;
 extern crate time;
 extern crate chrono;
 extern crate bytesize;
+extern crate serde;
 #[cfg_attr(any(target_os = "freebsd", target_os = "openbsd", target_os = "macos"), macro_use)]
 extern crate lazy_static;
 #[cfg(any(target_os = "linux", target_os = "android"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,11 +7,12 @@ extern crate libc;
 extern crate time;
 extern crate chrono;
 extern crate bytesize;
-extern crate serde;
 #[cfg_attr(any(target_os = "freebsd", target_os = "openbsd", target_os = "macos"), macro_use)]
 extern crate lazy_static;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 extern crate nom;
+#[cfg(feature = "serde")]
+extern crate serde;
 
 pub mod platform;
 pub mod data;


### PR DESCRIPTION
serde is the most popular crate for serializing and de-serializing structs, enums, etc. I added them to the public facing data types so users can serialize and de-serialize the data returned from this crate.