### PR TITLE
Add support for iOS

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -283,7 +283,7 @@ pub struct PlatformMemory {
     pub swonly: ByteSize,
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(target_vendor = "apple")]
 #[cfg_attr(
     feature = "serde",
     derive(Serialize, Deserialize),
@@ -339,7 +339,7 @@ pub struct Memory {
 ))]
 pub type PlatformSwap = PlatformMemory;
 
-#[cfg(any(target_os = "macos", target_os = "freebsd"))]
+#[cfg(any(target_vendor = "apple", target_os = "freebsd"))]
 #[cfg_attr(
     feature = "serde",
     derive(Serialize, Deserialize),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
         target_os = "freebsd",
         target_os = "openbsd",
         target_os = "netbsd",
-        target_os = "macos"
+        target_vendor = "apple"
     ),
     macro_use
 )]

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -14,7 +14,7 @@ pub mod unix;
     target_os = "freebsd",
     target_os = "openbsd",
     target_os = "netbsd",
-    target_os = "macos"
+    target_vendor = "apple"
 ))]
 pub mod bsd;
 
@@ -33,9 +33,9 @@ pub mod netbsd;
 #[cfg(target_os = "netbsd")]
 pub use self::netbsd::PlatformImpl;
 
-#[cfg(target_os = "macos")]
+#[cfg(target_vendor = "apple")]
 pub mod macos;
-#[cfg(target_os = "macos")]
+#[cfg(target_vendor = "apple")]
 pub use self::macos::PlatformImpl;
 
 #[cfg(any(target_os = "linux", target_os = "android"))]


### PR DESCRIPTION
Without this change, this crate and any dependents on it fail to build for iOS.

You can test on a Mac with `cargo build --target aarch64-apple-ios`