### PR TITLE
enable procfs for android

### DIFF
--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -10,7 +10,7 @@ pub use self::windows::PlatformImpl;
 #[cfg(unix)]
 pub mod unix;
 
-#[cfg(any(target_os = "linux", target_os = "hurd"))]
+#[cfg(any(target_os = "linux", target_os = "android", target_os = "hurd"))]
 mod procfs;
 
 #[cfg(any(


### PR DESCRIPTION
Android has `/proc`, so this can be enabled. I'm not certain if all the same files are available as a standard Linux system, but that doesn't really matter as in this case, an error would just be returned to the caller.

Fixes #132
